### PR TITLE
Add history logging to Markdown files

### DIFF
--- a/JZLLMContext.xcodeproj/project.pbxproj
+++ b/JZLLMContext.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1C2B45E4AA8EE0C9E320128D /* HotkeyRecorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299358F7A9CBA63430E341F7 /* HotkeyRecorderView.swift */; };
 		22887C026E9224A0D2923C8A /* ConnectionTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4788917E973F02208D6DAB08 /* ConnectionTester.swift */; };
 		29688E8CAB94FFBD58DD2D42 /* HistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB65AD326E16BF2E0137AABE /* HistoryStore.swift */; };
+		D1A2B3C4E5F6A7B8C9D0E1F2 /* HistoryLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F3A4B5C6D7E8F9A0B1C2D3 /* HistoryLogger.swift */; };
 		450734B8BB48675A75765886 /* OverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35D70E3B5C8380F38DF3181F /* OverlayView.swift */; };
 		4FF3E3C125C7FAE2DB6C23D8 /* ActionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC8DF5CAF58138FC3521135 /* ActionEngine.swift */; };
 		55A7384824E1E417674390AE /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43A0987C8886320AB4C42709 /* AboutView.swift */; };
@@ -126,6 +127,15 @@
 			path = Engine;
 			sourceTree = "<group>";
 		};
+		F4A5B6C7D8E9F0A1B2C3D4E5 /* Logging */ = {
+			isa = PBXGroup;
+			children = (
+				E2F3A4B5C6D7E8F9A0B1C2D3 /* HistoryLogger.swift */,
+			);
+			path = Logging;
+			sourceTree = "<group>";
+		};
+		E2F3A4B5C6D7E8F9A0B1C2D3 /* HistoryLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryLogger.swift; sourceTree = "<group>"; };
 		A07FF79AF12DA12FB072396E = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +154,7 @@
 				EC220C3994F500842554EEFF /* Config */,
 				2FCC534B033C3D03A572CD65 /* Context */,
 				97D272CB3B3203A44B69AACF /* Engine */,
+				F4A5B6C7D8E9F0A1B2C3D4E5 /* Logging */,
 				F2E4204E670981FBC48E3A17 /* Providers */,
 				718F97CD4327087AD4B44AA1 /* Resources */,
 				3540DFB725C97E3561198B61 /* UI */,
@@ -273,6 +284,7 @@
 				22887C026E9224A0D2923C8A /* ConnectionTester.swift in Sources */,
 				0C3A306A2EAF3CCD2796ACC4 /* ContextResolver.swift in Sources */,
 				29688E8CAB94FFBD58DD2D42 /* HistoryStore.swift in Sources */,
+				D1A2B3C4E5F6A7B8C9D0E1F2 /* HistoryLogger.swift in Sources */,
 				7C7F7BE7E9C1F5004DA1382B /* HotkeyManager.swift in Sources */,
 				1C2B45E4AA8EE0C9E320128D /* HotkeyRecorderView.swift in Sources */,
 				64E461412076DEC8DDBD2D48 /* KeychainStore.swift in Sources */,

--- a/Sources/JZLLMContext/Config/AppConfig.swift
+++ b/Sources/JZLLMContext/Config/AppConfig.swift
@@ -94,6 +94,10 @@ struct AppConfig: Codable {
     var modelPresets: [String: [ModelPreset]] = [:]
     var autoUpdateCheck: Bool = true
     var appLanguage: AppLanguage = .system
+    var historyLogEnabled: Bool = false
+    var historyLogDirectory: String? = nil
+    var historyLogWarningShown: Bool = false
+    var historyLogFilePrefix: String = ""
 
     static let defaultAzureAPIVersion = "2024-10-21"
 
@@ -105,7 +109,11 @@ struct AppConfig: Codable {
          autoCopyAndClose: Bool = false, historyLimit: Int = 5, markdownOutput: Bool = true,
          modelPresets: [String: [ModelPreset]] = [:],
          autoUpdateCheck: Bool = true,
-         appLanguage: AppLanguage = .system) {
+         appLanguage: AppLanguage = .system,
+         historyLogEnabled: Bool = false,
+         historyLogDirectory: String? = nil,
+         historyLogWarningShown: Bool = false,
+         historyLogFilePrefix: String = "") {
         self.schemaVersion = schemaVersion
         self.hotkeyKeyCode = hotkeyKeyCode
         self.hotkeyModifiers = hotkeyModifiers
@@ -128,6 +136,10 @@ struct AppConfig: Codable {
         self.modelPresets = modelPresets
         self.autoUpdateCheck = autoUpdateCheck
         self.appLanguage = appLanguage
+        self.historyLogEnabled = historyLogEnabled
+        self.historyLogDirectory = historyLogDirectory
+        self.historyLogWarningShown = historyLogWarningShown
+        self.historyLogFilePrefix = historyLogFilePrefix
     }
 
     init(from decoder: Decoder) throws {
@@ -154,6 +166,10 @@ struct AppConfig: Codable {
         modelPresets = try c.decodeIfPresent([String: [ModelPreset]].self, forKey: .modelPresets) ?? [:]
         autoUpdateCheck = try c.decodeIfPresent(Bool.self, forKey: .autoUpdateCheck) ?? true
         appLanguage = try c.decodeIfPresent(AppLanguage.self, forKey: .appLanguage) ?? .system
+        historyLogEnabled = try c.decodeIfPresent(Bool.self, forKey: .historyLogEnabled) ?? false
+        historyLogDirectory = try c.decodeIfPresent(String.self, forKey: .historyLogDirectory)
+        historyLogWarningShown = try c.decodeIfPresent(Bool.self, forKey: .historyLogWarningShown) ?? false
+        historyLogFilePrefix = try c.decodeIfPresent(String.self, forKey: .historyLogFilePrefix) ?? ""
     }
 
     static var `default`: AppConfig { makeDefault() }

--- a/Sources/JZLLMContext/Engine/ActionEngine.swift
+++ b/Sources/JZLLMContext/Engine/ActionEngine.swift
@@ -22,6 +22,11 @@ final class ActionEngine: ObservableObject {
                 for try await chunk in provider.stream(systemPrompt: action.systemPrompt, userContent: input) {
                     result += chunk
                 }
+                let finalResult = result
+                let language = ConfigStore.shared.config.appLanguage
+                Task.detached {
+                    await HistoryLogger.shared.log(action: action, input: input, response: finalResult, language: language)
+                }
             } catch is CancellationError {
                 return
             } catch let urlError as URLError where urlError.code == .cancelled {

--- a/Sources/JZLLMContext/Logging/HistoryLogger.swift
+++ b/Sources/JZLLMContext/Logging/HistoryLogger.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+actor HistoryLogger {
+    static let shared = HistoryLogger()
+    private init() {}
+
+    private lazy var fileDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
+    private lazy var timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss"
+        return f
+    }()
+
+    private var handleCache: [String: FileHandle] = [:]
+
+    func log(action: Action, input: String, response: String, language: AppLanguage, at date: Date = .init()) async {
+        let config = ConfigStore.shared.config
+        guard config.historyLogEnabled, let dirPath = config.historyLogDirectory, !response.isEmpty else { return }
+
+        let dateStr = fileDateFormatter.string(from: date)
+        let prefix = config.historyLogFilePrefix
+        let fileName = prefix.isEmpty ? "\(dateStr).md" : "\(prefix)\(dateStr).md"
+        let dirURL = URL(fileURLWithPath: dirPath)
+        let fileURL = dirURL.appendingPathComponent(fileName)
+        let filePath = fileURL.path
+
+        do {
+            try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+
+            let isNewFile = !FileManager.default.fileExists(atPath: filePath)
+            if isNewFile {
+                FileManager.default.createFile(atPath: filePath, contents: nil)
+            }
+
+            let handle: FileHandle
+            if let cached = handleCache[filePath] {
+                handle = cached
+            } else {
+                handle = try FileHandle(forWritingTo: fileURL)
+                handleCache[filePath] = handle
+            }
+
+            let entry = format(action: action, input: input, response: response,
+                               language: language, date: date,
+                               isNewFile: isNewFile, dateStr: dateStr)
+            guard let data = entry.data(using: .utf8) else { return }
+
+            handle.seekToEndOfFile()
+            try handle.write(contentsOf: data)
+        } catch {
+            handleCache[filePath] = nil
+            fputs("[HistoryLogger] \(error)\n", stderr)
+        }
+    }
+
+    func resetHandleCache() async {
+        for handle in handleCache.values {
+            try? handle.close()
+        }
+        handleCache = [:]
+    }
+
+    private func format(action: Action, input: String, response: String,
+                        language: AppLanguage, date: Date,
+                        isNewFile: Bool, dateStr: String) -> String {
+        let timeStr = timeFormatter.string(from: date)
+        let (lAction, lModel, lInput, lResponse) = labels(for: language)
+        let providerModel = "\(action.provider.rawValue) / \(action.model)"
+
+        var result = ""
+        if isNewFile {
+            result += "# JZLLMContext — \(dateStr)\n"
+        }
+        result += """
+
+        ## \(timeStr)
+
+        **\(lAction):** \(action.name)
+        **\(lModel):** \(providerModel)
+
+        **\(lInput):**
+        \(input)
+
+        **\(lResponse):**
+        \(response)
+
+        ---
+        """
+        return result
+    }
+
+    private func labels(for language: AppLanguage) -> (String, String, String, String) {
+        let code = language.resolvedLocale.language.languageCode?.identifier ?? "en"
+        switch code {
+        case "cs": return ("Akce", "Model", "Vstup", "Odpověď")
+        case "es": return ("Acción", "Modelo", "Entrada", "Respuesta")
+        default:   return ("Action", "Model", "Input", "Response")
+        }
+    }
+}

--- a/Sources/JZLLMContext/Resources/Localizable.xcstrings
+++ b/Sources/JZLLMContext/Resources/Localizable.xcstrings
@@ -147,6 +147,86 @@
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Reiniciar ahora" } }
       }
     },
+    "settings.general.section.logging" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Logování do souborů" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "History Logging" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Registro de historial" } }
+      }
+    },
+    "settings.general.logging.toggle" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Ukládat interakce do Markdown souborů" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Log interactions to Markdown files" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Registrar interacciones en archivos Markdown" } }
+      }
+    },
+    "settings.general.logging.directory_label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Adresář pro logy:" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Log directory:" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Directorio de registro:" } }
+      }
+    },
+    "settings.general.logging.no_directory" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nevybráno" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Not selected" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "No seleccionado" } }
+      }
+    },
+    "settings.general.logging.choose_button" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Vybrat…" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Choose…" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Elegir…" } }
+      }
+    },
+    "settings.general.logging.prefix_label" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Prefix názvu souboru:" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "File name prefix:" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Prefijo del nombre de archivo:" } }
+      }
+    },
+    "settings.general.logging.caption" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Logy mohou obsahovat obsah schránky a odpovědi LLM." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Logs may contain clipboard content and LLM responses." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Los registros pueden contener contenido del portapapeles y respuestas de LLM." } }
+      }
+    },
+    "settings.general.logging.alert.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Upozornění na citlivá data" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sensitive Data Warning" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Advertencia de datos sensibles" } }
+      }
+    },
+    "settings.general.logging.alert.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Povolení zapíše obsah schránky a odpovědi LLM do textových souborů. Ujistěte se, že je cílový adresář zabezpečený." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enabling this will write clipboard content and LLM responses to plain text files on disk. Make sure the log directory is secure." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Al activar esto, el contenido del portapapeles y las respuestas de LLM se guardarán en archivos de texto. Asegúrese de que el directorio sea seguro." } }
+      }
+    },
+    "settings.general.logging.alert.enable" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Povolit logování" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enable Logging" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Activar registro" } }
+      }
+    },
     "settings.general.section.backup" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/JZLLMContext/UI/SettingsView.swift
+++ b/Sources/JZLLMContext/UI/SettingsView.swift
@@ -36,6 +36,7 @@ struct SettingsView: View {
     @State private var reviewingProvider: ProviderType? = nil
     @State private var showResetAlert = false
     @State private var showRestartAlert = false
+    @State private var showLogWarning = false
     @State private var updateState: UpdateState = .idle
 
     private enum UpdateState: Equatable {
@@ -118,6 +119,47 @@ struct SettingsView: View {
                 Text(L("settings.general.language.restart.message"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+            }
+            Section(L("settings.general.section.logging")) {
+                Toggle(L("settings.general.logging.toggle"), isOn: $config.historyLogEnabled)
+                    .onChange(of: config.historyLogEnabled) { _, enabled in
+                        if enabled {
+                            if !config.historyLogWarningShown {
+                                config.historyLogEnabled = false
+                                showLogWarning = true
+                            } else if config.historyLogDirectory == nil {
+                                selectLogDirectory()
+                            } else {
+                                ConfigStore.shared.update { $0.historyLogEnabled = true }
+                            }
+                        } else {
+                            ConfigStore.shared.update { $0.historyLogEnabled = false }
+                        }
+                    }
+                if config.historyLogEnabled || config.historyLogDirectory != nil {
+                    HStack {
+                        Text(L("settings.general.logging.directory_label"))
+                            .foregroundStyle(.secondary)
+                        Text(config.historyLogDirectory ?? L("settings.general.logging.no_directory"))
+                            .lineLimit(1)
+                            .truncationMode(.head)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Button(L("settings.general.logging.choose_button")) { selectLogDirectory() }
+                    }
+                    HStack {
+                        Text(L("settings.general.logging.prefix_label"))
+                            .foregroundStyle(.secondary)
+                        TextField("", text: $config.historyLogFilePrefix)
+                            .frame(maxWidth: 200)
+                            .onChange(of: config.historyLogFilePrefix) { _, val in
+                                ConfigStore.shared.update { $0.historyLogFilePrefix = val }
+                                Task { await HistoryLogger.shared.resetHandleCache() }
+                            }
+                    }
+                    Text(L("settings.general.logging.caption"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
             Section(L("settings.general.section.backup")) {
                 Text(L("settings.general.backup.description"))
@@ -224,6 +266,38 @@ struct SettingsView: View {
             Button(L("common.later"), role: .cancel) {}
         } message: {
             Text(L("settings.general.language.restart.message"))
+        }
+        .alert(L("settings.general.logging.alert.title"), isPresented: $showLogWarning) {
+            Button(L("settings.general.logging.alert.enable")) { selectLogDirectory() }
+            Button(L("common.cancel"), role: .cancel) { }
+        } message: {
+            Text(L("settings.general.logging.alert.message"))
+        }
+    }
+
+    private func selectLogDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.prompt = L("settings.general.logging.choose_button")
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else {
+                if !config.historyLogWarningShown {
+                    config.historyLogEnabled = false
+                    ConfigStore.shared.update { $0.historyLogEnabled = false }
+                }
+                return
+            }
+            config.historyLogDirectory = url.path
+            config.historyLogEnabled = true
+            config.historyLogWarningShown = true
+            ConfigStore.shared.update {
+                $0.historyLogDirectory = url.path
+                $0.historyLogEnabled = true
+                $0.historyLogWarningShown = true
+            }
+            Task { await HistoryLogger.shared.resetHandleCache() }
         }
     }
 


### PR DESCRIPTION
## Summary
This PR adds a new history logging feature that allows users to automatically log LLM interactions to Markdown files on disk. Users can enable logging, configure the output directory, and optionally set a file name prefix through the settings UI.

## Key Changes
- **New `HistoryLogger` actor**: Implements file-based logging with caching of file handles for efficient writes. Logs are formatted as Markdown with timestamps, action details, input, and responses. Supports multiple languages (English, Czech, Spanish) for log labels.
- **Configuration additions**: Extended `AppConfig` with four new properties:
  - `historyLogEnabled`: Toggle for the feature
  - `historyLogDirectory`: Path to the log directory
  - `historyLogWarningShown`: Tracks if the user has seen the sensitive data warning
  - `historyLogFilePrefix`: Optional prefix for log file names
- **Settings UI**: Added a new "History Logging" section in Settings with:
  - Toggle to enable/disable logging
  - Directory picker with "Choose..." button
  - Text field for file name prefix
  - Warning caption about sensitive data
  - Confirmation alert before first-time enablement
- **Integration with ActionEngine**: Automatically logs each LLM interaction after successful completion
- **Localization**: Added 10 new localized strings for English, Czech, and Spanish covering all UI elements and warnings

## Implementation Details
- The `HistoryLogger` uses an actor for thread-safe file operations
- File handles are cached by file path to avoid repeated open/close operations
- Log files are created daily with format: `[prefix]YYYY-MM-DD.md`
- Each interaction is appended with a header, metadata, input/output sections, and separator
- The feature includes a sensitive data warning that must be acknowledged before first use
- Directory selection uses `NSOpenPanel` with ability to create new directories
- Cache is reset when the file prefix changes to ensure proper file naming

https://claude.ai/code/session_01A3Qo4XoEyZasDxuMfKZkaX