### PR TITLE
Refactor ProgressView sizing and improve UI styling consistency

### DIFF
--- a/Sources/JZLLMContext/UI/AboutView.swift
+++ b/Sources/JZLLMContext/UI/AboutView.swift
@@ -141,7 +141,7 @@ struct AboutView: View {
             iconRow("return.left",                L("about.icons.default_action"), color: .accentColor)
             HStack(alignment: .center, spacing: 12) {
                 ProgressView()
-                    .scaleEffect(0.6)
+                    .controlSize(.small)
                     .frame(width: 20, height: 16)
                 Text(L("about.icons.action_running"))
                     .font(.callout)

--- a/Sources/JZLLMContext/UI/ActionDetailSheet.swift
+++ b/Sources/JZLLMContext/UI/ActionDetailSheet.swift
@@ -99,7 +99,7 @@ struct ActionDetailSheet: View {
                 TextEditor(text: $systemPrompt)
                     .font(.callout)
                     .frame(minHeight: 140, maxHeight: 300)
-                    .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.secondary.opacity(0.3)))
+                    .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5))
             } else {
                 ScrollView {
                     Text(action.systemPrompt)
@@ -109,8 +109,8 @@ struct ActionDetailSheet: View {
                         .padding(8)
                 }
                 .frame(minHeight: 80, maxHeight: 260)
-                .background(Color(nsColor: .textBackgroundColor).opacity(0.6))
-                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .background(Color(nsColor: .textBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
             }
         }
     }

--- a/Sources/JZLLMContext/UI/OverlayView.swift
+++ b/Sources/JZLLMContext/UI/OverlayView.swift
@@ -195,7 +195,7 @@ struct OverlayView: View {
             }
         }
         .padding(8)
-        .background(Color(nsColor: .textBackgroundColor).opacity(0.6))
+        .background(Color(nsColor: .controlBackgroundColor))
         .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
@@ -234,7 +234,7 @@ struct OverlayView: View {
             .help(ignoreClipboard ? L("overlay.help.use_clipboard") : L("overlay.help.ignore_clipboard"))
         }
         .padding(8)
-        .background(Color(nsColor: .textBackgroundColor).opacity(ignoreClipboard ? 0.3 : 0.6))
+        .background(Color(nsColor: .controlBackgroundColor).opacity(ignoreClipboard ? 0.4 : 1))
         .clipShape(RoundedRectangle(cornerRadius: 6))
     }
 
@@ -272,7 +272,7 @@ struct OverlayView: View {
                 Text(title)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 if isRunning {
-                    ProgressView().scaleEffect(0.65)
+                    ProgressView().controlSize(.small)
                 } else if missingKey {
                     Image(systemName: "exclamationmark.triangle")
                         .foregroundStyle(.orange)

--- a/Sources/JZLLMContext/UI/SettingsView.swift
+++ b/Sources/JZLLMContext/UI/SettingsView.swift
@@ -166,7 +166,7 @@ struct SettingsView: View {
                     case .idle:
                         EmptyView()
                     case .checking:
-                        ProgressView().scaleEffect(0.7)
+                        ProgressView().controlSize(.small)
                     case .upToDate:
                         Label(L("settings.general.update.up_to_date"), systemImage: "checkmark.circle.fill")
                             .foregroundStyle(.green)
@@ -519,7 +519,7 @@ struct SettingsView: View {
             } label: {
                 if isFetching == provider {
                     HStack(spacing: 6) {
-                        ProgressView().scaleEffect(0.7)
+                        ProgressView().controlSize(.small)
                         Text(L("settings.providers.fetching"))
                     }
                 } else {
@@ -562,7 +562,7 @@ struct SettingsView: View {
             } label: {
                 if isTesting == provider {
                     HStack(spacing: 6) {
-                        ProgressView().scaleEffect(0.7)
+                        ProgressView().controlSize(.small)
                         Text(L("settings.providers.testing"))
                     }
                 } else {
@@ -757,7 +757,7 @@ private struct ActionRow: View {
             TextEditor(text: $action.systemPrompt)
                 .font(.callout)
                 .frame(minHeight: 60, maxHeight: 100)
-                .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.secondary.opacity(0.3)))
+                .overlay(RoundedRectangle(cornerRadius: 4).strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5))
 
             parametersRow
         }


### PR DESCRIPTION
## Summary
This PR improves the UI consistency and styling across the application by replacing manual ProgressView scaling with the native `controlSize(.small)` modifier and refining border and background styling for better visual hierarchy.

## Key Changes
- **ProgressView sizing**: Replaced `scaleEffect()` calls with `controlSize(.small)` modifier across multiple views (SettingsView, OverlayView, AboutView) for more consistent and maintainable sizing
- **TextEditor borders**: Updated from `stroke(Color.secondary.opacity(0.3))` to `strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5)` for crisper, more defined borders in SettingsView and ActionDetailSheet
- **Background styling**: 
  - Removed opacity modifiers from text background colors in ActionDetailSheet and OverlayView for more opaque, readable backgrounds
  - Changed OverlayView background from `.textBackgroundColor` to `.controlBackgroundColor` for better visual consistency
  - Adjusted opacity values in conditional backgrounds for improved visual distinction
- **Corner radius**: Increased corner radius from 4 to 6 in ActionDetailSheet for better visual consistency with other UI elements

## Implementation Details
- All ProgressView changes maintain the same visual intent while using SwiftUI's native control sizing system
- Border styling changes use system separator colors for better theme adaptation
- Background color changes leverage macOS system colors for improved consistency with system appearance

https://claude.ai/code/session_01RaVNy7cKm3xGRXpksVtvmf