### PR TITLE
Replace fixed custom provider slots with dynamic unlimited providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Copy text or an image, press the global shortcut, and the selected action sends 
   - [Settings – Actions](#settings--actions)
   - [Settings – Providers](#settings--providers)
 - [Custom Models](#custom-models)
-- [Custom OpenAI-Compatible Provider](#custom-openai-compatible-provider)
+- [Custom OpenAI-Compatible Providers](#custom-openai-compatible-providers)
 - [Uninstalling](#uninstalling)
 - [Technical Overview](#technical-overview)
 - [Disclaimer](#disclaimer)
@@ -143,7 +143,9 @@ All changes are saved immediately.
 
 **Azure AI (slot 1 and slot 2)** – each slot represents one deployment in Azure AI Foundry. Enter the API key, Deployment URL, and API version.
 
-**Custom OpenAI-compatible (slot 1 and slot 2)** – any server compatible with the OpenAI Chat Completions API. Enter the Base URL, optionally an API key (can be left empty for local models), optionally an **API version** (appends `?api-version=…` to the URL), and the **Max tokens parameter** – select the token limit parameter name (`max_tokens`, `max_completion_tokens`, `max_output_tokens`, `max_new_tokens`) based on what the server expects. **Update Models** fetches the model list from the server's `/models` endpoint (compatible with Ollama, LM Studio, and most OpenAI-compatible servers); manual model entry per action always remains available.
+**Custom OpenAI-compatible providers** – any number of custom providers compatible with the OpenAI Chat Completions API. Add a provider with the **+** button and configure: provider name (used in the action picker and all UI), Base URL, optionally an API key (leave empty for local models), optionally an **API version** (appends `?api-version=…` to the URL), the **Max tokens parameter** (`max_tokens`, `max_completion_tokens`, `max_output_tokens`, `max_new_tokens` – select based on what the server expects), and optional **Custom Headers** (extra HTTP headers sent with every request – useful for authentication headers, API routing, or service-specific requirements). **Update Models** fetches the model list from the server's `/models` endpoint (compatible with Ollama, LM Studio, and most OpenAI-compatible servers); manual model entry per action always remains available. Providers can be removed with the delete button; actions using the deleted provider are automatically reset to OpenAI.
+
+**Model Filters** – global filters that apply across all providers. The **Exclude** list hides any model whose ID contains one of the specified strings (e.g. adding `preview` hides all preview models). The **Include** list, when non-empty, shows only models whose ID contains at least one of the specified strings. Include takes priority over exclude. Filters apply in the action model picker and in the Update Models sheet.
 
 The **Verify Connection** button for each provider sends a test request and displays the result.
 
@@ -160,18 +162,19 @@ Each provider offers a predefined model list and the option to enter any model m
 | Google Gemini | gemini-2.5-pro, gemini-2.5-flash, gemini-2.0-flash (legacy) |
 | xAI Grok | grok-3, grok-3-mini, grok-2 (legacy) |
 | Azure AI (slot 1 / slot 2) | – (model is determined by the deployment configuration) |
-| Custom API (slot 1 / slot 2) | fetched via Update Models (if server supports `/models`); manual entry always available |
+| Custom providers | fetched via Update Models (if server supports `/models`); manual entry always available |
 
 To use a custom model: in the action settings, open the model picker → select "Custom model…" → enter the exact model identifier (e.g. `gpt-4.5-preview`). The value is saved immediately.
 
 ---
 
-### Custom OpenAI-Compatible Provider
+### Custom OpenAI-Compatible Providers
 
-The app supports any server compatible with the OpenAI Chat Completions API via two independent slots.
+The app supports any number of custom providers compatible with the OpenAI Chat Completions API. Add them in **Settings → Providers** using the **+** button. Each provider has an independent name, API key, and configuration.
 
 **Ollama (local models)**
 ```
+Name:     Ollama
 Base URL: http://localhost:11434/v1
 API key:  (leave empty)
 Model:    llama3.2, mistral, ...
@@ -179,16 +182,28 @@ Model:    llama3.2, mistral, ...
 
 **LM Studio**
 ```
+Name:     LM Studio
 Base URL: http://localhost:1234/v1
 API key:  (leave empty or any string)
 Model:    (name of the model loaded in LM Studio)
 ```
 
-**Another cloud provider**
+**Another cloud provider (e.g. Together AI)**
 ```
+Name:     Together AI
 Base URL: https://api.together.xyz/v1
 API key:  <your key>
 Model:    meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo
+```
+
+**OpenRouter (with custom headers)**
+```
+Name:           OpenRouter
+Base URL:       https://openrouter.ai/api/v1
+API key:        <your OpenRouter key>
+Custom Headers: HTTP-Referer: https://your-app.example.com
+                X-Title: YourAppName
+Model:          (any OpenRouter model ID)
 ```
 
 ---
@@ -217,8 +232,8 @@ security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.gemin
 security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.grok.apikey"
 security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.azure_openai.apikey"
 security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.azure_openai_2.apikey"
-security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.custom_openai.apikey"
-security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.custom_openai_2.apikey"
+# For each custom provider, replace <uuid> with the provider's UUID from config.json:
+security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.<uuid>.apikey"
 ```
 
 If "Launch at Login" was enabled, unregister the app in Settings → General before deleting it. macOS usually removes the registration automatically when the `.app` bundle is deleted.
@@ -231,7 +246,7 @@ If "Launch at Login" was enabled, unregister the app in Settings → General bef
 
 - **Global shortcut** – opens the overlay panel with clipboard content from anywhere (default: Cmd+Shift+Space)
 - **Text and images** – reads text from the clipboard or extracts text from images via Apple Vision OCR
-- **Multiple providers** – OpenAI, Anthropic, Google Gemini, xAI Grok, Azure AI (2 slots), custom OpenAI-compatible endpoint – 2 slots (Ollama, LM Studio, …)
+- **Multiple providers** – OpenAI, Anthropic, Google Gemini, xAI Grok, Azure AI (2 slots), unlimited custom OpenAI-compatible providers (Ollama, LM Studio, OpenRouter, …)
 - **Custom actions** – any number of actions with system prompts; each has its own provider, model, temperature, and token limit
 - **Action management** – enable/disable, drag & drop reordering, delete with confirmation, import/export as JSON
 - **Custom models** – each provider supports entering any model beyond the predefined list
@@ -246,6 +261,8 @@ If "Launch at Login" was enabled, unregister the app in Settings → General bef
 - **Auto copy and close** – global toggle and per-action override (Always / Never / Use global setting)
 - **Result formatting** – global toggle; result can be shown with Markdown formatting or as plain text
 - **Online model list refresh** – fetch current models directly from the API via the provider settings button; custom OpenAI-compatible providers query the server's `/models` endpoint
+- **Model filters** – global include and exclude filter lists; models whose ID contains an exclude string are hidden across all providers; if any include strings are set, only matching models are shown; filters apply in the model picker and the Update Models sheet
+- **Custom HTTP headers** – each custom provider can send arbitrary extra HTTP headers with every request (useful for API routing, authentication, or service-specific requirements like `HTTP-Referer` on OpenRouter)
 - **Connection test** – verifies that the API key and configuration are working
 - **Configuration backup** – export/import the full configuration as JSON; API keys are not exported
 - **Configuration reset** – restore default settings with one click; API keys in the Keychain are preserved
@@ -305,7 +322,7 @@ ConfigStore (singleton)       – read/write config.json
 KeychainStore                 – store API keys in macOS Keychain
 ContextResolver               – read NSPasteboard + Vision OCR
 ProviderFactory               – create LLMProvider based on action config
-  ├── OpenAIProvider           – OpenAI + Azure OpenAI (2 slots) + custom endpoint (2 slots)
+  ├── OpenAIProvider           – OpenAI + Azure OpenAI (2 slots) + dynamic custom endpoints
   └── AnthropicProvider        – Anthropic Claude
 ```
 
@@ -345,8 +362,7 @@ API keys are stored in the macOS Keychain under service `com.jz.JZLLMContext`:
 | xAI Grok | `jzllmcontext.grok.apikey` |
 | Azure AI slot 1 | `jzllmcontext.azure_openai.apikey` |
 | Azure AI slot 2 | `jzllmcontext.azure_openai_2.apikey` |
-| Custom API slot 1 | `jzllmcontext.custom_openai.apikey` |
-| Custom API slot 2 | `jzllmcontext.custom_openai_2.apikey` |
+| Custom provider | `jzllmcontext.<uuid>.apikey` (UUID is assigned per provider on creation) |
 
 #### Configuration File Structure
 
@@ -372,12 +388,30 @@ API keys are stored in the macOS Keychain under service `com.jz.JZLLMContext`:
   "azureDeploymentName2": null,
   "azureEndpoint2": null,
   "azureAPIVersion2": null,
-  "customOpenAIBaseURL": "http://localhost:11434/v1",
-  "customOpenAIAPIVersion": null,
-  "customOpenAITokenParam": "max_tokens",
-  "customOpenAIBaseURL2": null,
-  "customOpenAIAPIVersion2": null,
-  "customOpenAITokenParam2": "max_tokens",
+  "customProviders": [
+    {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "name": "Ollama",
+      "baseURL": "http://localhost:11434/v1",
+      "apiVersion": null,
+      "tokenParamStyle": "max_tokens",
+      "requiresAPIKey": false,
+      "customHeaders": {}
+    },
+    {
+      "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+      "name": "OpenRouter",
+      "baseURL": "https://openrouter.ai/api/v1",
+      "apiVersion": null,
+      "tokenParamStyle": "max_tokens",
+      "requiresAPIKey": true,
+      "customHeaders": {
+        "HTTP-Referer": "https://your-app.example.com"
+      }
+    }
+  ],
+  "modelExcludeFilters": ["preview", "instruct"],
+  "modelIncludeFilters": [],
   "autoUpdateCheck": true,
   "autoCopyAndClose": false,
   "historyLimit": 5,
@@ -385,13 +419,13 @@ API keys are stored in the macOS Keychain under service `com.jz.JZLLMContext`:
   "hotkeyKeyCode": 49,
   "hotkeyModifiers": 768,
   "modelPresets": {},
-  "schemaVersion": 1
+  "schemaVersion": 2
 }
 ```
 
 `hotkeyKeyCode` and `hotkeyModifiers` are Carbon API codes. The default shortcut Cmd+Shift+Space corresponds to `keyCode: 49`, `modifiers: 768`.
 
-Provider is stored as a string: `"openai"`, `"anthropic"`, `"gemini"`, `"grok"`, `"azure_openai"`, `"azure_openai_2"`, `"custom_openai"`, `"custom_openai_2"`.
+Provider is stored as a string: `"openai"`, `"anthropic"`, `"gemini"`, `"grok"`, `"azure_openai"`, `"azure_openai_2"`, or the UUID string of a custom provider (e.g. `"a1b2c3d4-e5f6-7890-abcd-ef1234567890"`).
 
 #### Providers and Their Details
 
@@ -403,8 +437,7 @@ Provider is stored as a string: `"openai"`, `"anthropic"`, `"gemini"`, `"grok"`,
 | xAI Grok | `https://api.x.ai/v1/chat/completions` | 0.0–2.0 | OpenAI-compatible endpoint; Bearer auth |
 | Azure AI (slot 1) | `{endpoint}/chat/completions?api-version=...` | 0.0–2.0 | `api-key: {key}` header; model in body is ignored – model is determined by the deployment |
 | Azure AI (slot 2) | same as slot 1, different config | 0.0–2.0 | Independent slot for a second deployment |
-| Custom API (slot 1) | `{customBaseURL}/chat/completions` | 0.0–2.0 | OpenAI Chat Completions protocol; API key and API version are optional |
-| Custom API (slot 2) | same as slot 1, different config | 0.0–2.0 | Independent slot for a second custom endpoint |
+| Custom provider (any) | `{baseURL}/chat/completions` | 0.0–2.0 | OpenAI Chat Completions protocol; API key, API version, and custom headers are all optional; supports Ollama, LM Studio, OpenRouter, Together AI, etc. |
 
 All HTTP requests time out after **60 seconds**.
 
@@ -455,7 +488,7 @@ Zkopíruješ text nebo obrázek, stiskneš globální zkratku a vybraná akce po
   - [Nastavení – Akce](#nastavení--akce)
   - [Nastavení – Providery](#nastavení--providery)
 - [Vlastní modely](#vlastní-modely)
-- [Vlastní OpenAI-compatible provider](#vlastní-openai-compatible-provider)
+- [Vlastní OpenAI-compatible providery](#vlastní-openai-compatible-providery)
 - [Odinstalace](#odinstalace)
 - [Technický popis](#technický-popis)
 - [Zřeknutí se odpovědnosti](#zřeknutí-se-odpovědnosti)
@@ -573,7 +606,9 @@ Všechny změny se ukládají okamžitě.
 
 **Azure AI (slot 1 a slot 2)** – každý slot reprezentuje jedno nasazení (deployment) v Azure AI Foundry. Zadej API klíč, Deployment URL a API verzi.
 
-**Vlastní OpenAI-compatible (slot 1 a slot 2)** – libovolný server kompatibilní s OpenAI Chat Completions API. Zadej Base URL, volitelně API klíč (pro lokální modely lze nechat prázdné), volitelně **API verzi** (přidá parametr `api-version` do URL) a **Parametr max. tokenů** – výběr názvu parametru pro limit tokenů (`max_tokens`, `max_completion_tokens`, `max_output_tokens`, `max_new_tokens`) podle toho, co daný server očekává. **Aktualizovat modely** načte seznam modelů z endpointu `/models` na daném serveru (funguje s Ollama, LM Studio a většinou OpenAI-compatible serverů); ruční zadání modelu v akci zůstává vždy dostupné.
+**Vlastní OpenAI-compatible providery** – libovolný počet vlastních providerů kompatibilních s OpenAI Chat Completions API. Přidej provider tlačítkem **+** a nakonfiguruj: název providera (používá se ve výběru akce a v celém UI), Base URL, volitelně API klíč (pro lokální modely lze nechat prázdné), volitelně **API verzi** (přidá parametr `?api-version=…` do URL), **Parametr max. tokenů** (`max_tokens`, `max_completion_tokens`, `max_output_tokens`, `max_new_tokens` – zvol podle toho, co daný server očekává) a volitelné **Vlastní hlavičky** (extra HTTP hlavičky odeslané s každým požadavkem – pro autentizaci, směrování API nebo specifické požadavky serveru). **Aktualizovat modely** načte seznam modelů z endpointu `/models` na daném serveru (funguje s Ollama, LM Studio a většinou OpenAI-compatible serverů); ruční zadání modelu v akci zůstává vždy dostupné. Providery lze odebrat tlačítkem smazat; akce používající smazaný provider se automaticky resetují na OpenAI.
+
+**Filtry modelů** – globální filtry platné pro všechny providery. Seznam **Exclude** skryje každý model, jehož ID obsahuje zadaný řetězec (např. přidání `preview` skryje všechny preview modely). Seznam **Include**, je-li neprázdný, zobrazí jen modely, jejichž ID obsahuje alespoň jeden ze zadaných řetězců. Include má přednost před exclude. Filtry se uplatňují ve výběru modelu v akci i v listu Update Models.
 
 Tlačítko **Ověřit připojení** u každého providera odešle testovací požadavek a zobrazí výsledek.
 
@@ -590,18 +625,19 @@ Každý provider nabízí předdefinovaný seznam modelů a možnost zadat libov
 | Google Gemini | gemini-2.5-pro, gemini-2.5-flash, gemini-2.0-flash (legacy) |
 | xAI Grok | grok-3, grok-3-mini, grok-2 (legacy) |
 | Azure AI (slot 1 / slot 2) | – (model určuje deployment v nastavení) |
-| Vlastní API (slot 1 / slot 2) | načteno přes Aktualizovat modely (pokud server podporuje `/models`); ruční zadání vždy dostupné |
+| Vlastní providery | načteno přes Aktualizovat modely (pokud server podporuje `/models`); ruční zadání vždy dostupné |
 
 Výběr vlastního modelu: v nastavení akce otevři výběr modelu → vyber „Vlastní model…" → zadej přesný identifikátor (např. `gpt-4.5-preview`). Hodnota se uloží okamžitě.
 
 ---
 
-### Vlastní OpenAI-compatible provider
+### Vlastní OpenAI-compatible providery
 
-Aplikace podporuje libovolný server kompatibilní s OpenAI Chat Completions API – ve formě dvou nezávislých slotů.
+Aplikace podporuje libovolný počet vlastních providerů kompatibilních s OpenAI Chat Completions API. Přidej je v **Nastavení → Providery** tlačítkem **+**. Každý provider má nezávislý název, API klíč a konfiguraci.
 
 **Ollama (lokální modely)**
 ```
+Název:    Ollama
 Base URL: http://localhost:11434/v1
 API klíč: (nechat prázdné)
 Model:    llama3.2, mistral, ...
@@ -609,16 +645,28 @@ Model:    llama3.2, mistral, ...
 
 **LM Studio**
 ```
+Název:    LM Studio
 Base URL: http://localhost:1234/v1
 API klíč: (nechat prázdné nebo libovolný řetězec)
 Model:    (název modelu načteného v LM Studio)
 ```
 
-**Jiný cloud provider**
+**Jiný cloud provider (např. Together AI)**
 ```
+Název:    Together AI
 Base URL: https://api.together.xyz/v1
 API klíč: <tvůj klíč>
 Model:    meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo
+```
+
+**OpenRouter (s vlastními hlavičkami)**
+```
+Název:            OpenRouter
+Base URL:         https://openrouter.ai/api/v1
+API klíč:         <tvůj OpenRouter klíč>
+Vlastní hlavičky: HTTP-Referer: https://tvoje-appka.example.com
+                  X-Title: NazevAppky
+Model:            (libovolné model ID z OpenRouter)
 ```
 
 ---
@@ -647,8 +695,8 @@ security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.gemin
 security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.grok.apikey"
 security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.azure_openai.apikey"
 security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.azure_openai_2.apikey"
-security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.custom_openai.apikey"
-security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.custom_openai_2.apikey"
+# Pro každý vlastní provider nahraď <uuid> UUID providera z config.json:
+security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.<uuid>.apikey"
 ```
 
 Pokud bylo zapnuto „Spustit při přihlášení", odregistruj aplikaci před smazáním přes Nastavení → Obecné. macOS registraci většinou smaže automaticky při odstranění `.app` bundlu.
@@ -661,7 +709,7 @@ Pokud bylo zapnuto „Spustit při přihlášení", odregistruj aplikaci před s
 
 - **Globální zkratka** – otevře overlay panel s obsahem schránky odkudkoli (výchozí: Cmd+Shift+Space)
 - **Text i obrázky** – čte text ze schránky nebo extrahuje text z obrázků přes Apple Vision OCR
-- **Více providerů** – OpenAI, Anthropic, Google Gemini, xAI Grok, Azure AI (2 sloty), vlastní OpenAI-compatible endpoint – 2 sloty (Ollama, LM Studio, …)
+- **Více providerů** – OpenAI, Anthropic, Google Gemini, xAI Grok, Azure AI (2 sloty), neomezený počet vlastních OpenAI-compatible providerů (Ollama, LM Studio, OpenRouter, …)
 - **Vlastní akce** – libovolný počet akcí se systémovými prompty; každá má vlastní provider, model, teplotu a limit tokenů
 - **Správa akcí** – zapínání/vypínání, drag & drop řazení, mazání s potvrzením, import/export jako JSON
 - **Vlastní modely** – každý provider podporuje zadání libovolného modelu mimo předdefinovaný seznam
@@ -676,6 +724,8 @@ Pokud bylo zapnuto „Spustit při přihlášení", odregistruj aplikaci před s
 - **Automatické zkopírování a zavření** – globální přepínač i per-akce přepis (Vždy / Nikdy / Dle globálního nastavení)
 - **Formátování výsledku** – globální přepínač; výsledek lze zobrazit s Markdown formátováním nebo jako prostý text
 - **Aktualizace seznamu modelů online** – tlačítkem v nastavení providerů lze načíst aktuální modely přímo z API; vlastní OpenAI-compatible providery načítají modely z endpointu `/models` na daném serveru
+- **Filtry modelů** – globální seznamy include a exclude filtrů; modely jejichž ID obsahuje exclude řetězec jsou skryty u všech providerů; jsou-li zadány include řetězce, zobrazí se jen shodné modely; filtry se uplatňují ve výběru modelu i v listu Update Models
+- **Vlastní HTTP hlavičky** – každý vlastní provider může posílat libovolné extra HTTP hlavičky s každým požadavkem (pro API routing, autentizaci nebo specifické požadavky jako `HTTP-Referer` na OpenRouter)
 - **Test připojení** – ověří, zda je API klíč a konfigurace funkční
 - **Záloha konfigurace** – export/import celé konfigurace jako JSON; API klíče nejsou exportovány
 - **Reset konfigurace** – obnoví výchozí nastavení jedním kliknutím; API klíče v Keychainu zůstanou
@@ -735,7 +785,7 @@ ConfigStore (singleton)       – čtení/zápis config.json
 KeychainStore                 – ukládání API klíčů do macOS Keychain
 ContextResolver               – čtení NSPasteboard + Vision OCR
 ProviderFactory               – vytváření LLMProvider podle konfigurace akce
-  ├── OpenAIProvider           – OpenAI + Azure OpenAI (2 sloty) + vlastní endpoint (2 sloty)
+  ├── OpenAIProvider           – OpenAI + Azure OpenAI (2 sloty) + dynamické vlastní endpointy
   └── AnthropicProvider        – Anthropic Claude
 ```
 
@@ -773,8 +823,7 @@ API klíče jsou uloženy v macOS Keychain pod service `com.jz.JZLLMContext`:
 | xAI Grok | `jzllmcontext.grok.apikey` |
 | Azure AI slot 1 | `jzllmcontext.azure_openai.apikey` |
 | Azure AI slot 2 | `jzllmcontext.azure_openai_2.apikey` |
-| Vlastní API slot 1 | `jzllmcontext.custom_openai.apikey` |
-| Vlastní API slot 2 | `jzllmcontext.custom_openai_2.apikey` |
+| Vlastní provider | `jzllmcontext.<uuid>.apikey` (UUID přiřazeno při vytvoření providera) |
 
 #### Struktura konfiguračního souboru
 
@@ -800,12 +849,19 @@ API klíče jsou uloženy v macOS Keychain pod service `com.jz.JZLLMContext`:
   "azureDeploymentName2": null,
   "azureEndpoint2": null,
   "azureAPIVersion2": null,
-  "customOpenAIBaseURL": "http://localhost:11434/v1",
-  "customOpenAIAPIVersion": null,
-  "customOpenAITokenParam": "max_tokens",
-  "customOpenAIBaseURL2": null,
-  "customOpenAIAPIVersion2": null,
-  "customOpenAITokenParam2": "max_tokens",
+  "customProviders": [
+    {
+      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "name": "Ollama",
+      "baseURL": "http://localhost:11434/v1",
+      "apiVersion": null,
+      "tokenParamStyle": "max_tokens",
+      "requiresAPIKey": false,
+      "customHeaders": {}
+    }
+  ],
+  "modelExcludeFilters": ["preview"],
+  "modelIncludeFilters": [],
   "autoUpdateCheck": true,
   "autoCopyAndClose": false,
   "historyLimit": 5,
@@ -813,13 +869,13 @@ API klíče jsou uloženy v macOS Keychain pod service `com.jz.JZLLMContext`:
   "hotkeyKeyCode": 49,
   "hotkeyModifiers": 768,
   "modelPresets": {},
-  "schemaVersion": 1
+  "schemaVersion": 2
 }
 ```
 
 Hodnoty `hotkeyKeyCode` a `hotkeyModifiers` jsou kódy Carbon API. Výchozí zkratka Cmd+Shift+Space odpovídá `keyCode: 49`, `modifiers: 768`.
 
-Provider se ukládá jako string: `"openai"`, `"anthropic"`, `"gemini"`, `"grok"`, `"azure_openai"`, `"azure_openai_2"`, `"custom_openai"`, `"custom_openai_2"`.
+Provider se ukládá jako string: `"openai"`, `"anthropic"`, `"gemini"`, `"grok"`, `"azure_openai"`, `"azure_openai_2"`, nebo UUID string vlastního providera (např. `"a1b2c3d4-e5f6-7890-abcd-ef1234567890"`).
 
 #### Providery a jejich limity
 
@@ -831,8 +887,7 @@ Provider se ukládá jako string: `"openai"`, `"anthropic"`, `"gemini"`, `"grok"
 | xAI Grok | `https://api.x.ai/v1/chat/completions` | 0.0–2.0 | OpenAI-compatible endpoint; Bearer auth |
 | Azure AI (slot 1) | `{endpoint}/chat/completions?api-version=...` | 0.0–2.0 | Header `api-key: {key}`; model v body ignorován – model určuje deployment |
 | Azure AI (slot 2) | totéž jako slot 1, jiná konfigurace | 0.0–2.0 | Nezávislý slot pro druhý deployment |
-| Vlastní API (slot 1) | `{customBaseURL}/chat/completions` | 0.0–2.0 | OpenAI Chat Completions protokol; API klíč i API verze volitelné |
-| Vlastní API (slot 2) | totéž jako slot 1, jiná konfigurace | 0.0–2.0 | Nezávislý slot pro druhý custom endpoint |
+| Vlastní provider (libovolný) | `{baseURL}/chat/completions` | 0.0–2.0 | OpenAI Chat Completions protokol; API klíč, API verze i vlastní hlavičky jsou volitelné; funguje s Ollama, LM Studio, OpenRouter, Together AI atd. |
 
 Timeout všech HTTP požadavků: **60 sekund**.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Dynamic custom providers: replace the fixed two-slot "Custom API" system with an unlimited list of named custom OpenAI-compatible providers; each provider has its own name, Base URL, optional API key, API version, max-tokens parameter style, and custom HTTP headers
+- Custom HTTP headers per provider: arbitrary key-value headers sent with every request – enables API routing, authentication, and other provider-specific requirements (e.g. `HTTP-Referer`, `X-Org-ID`)
+- Global model filters: exclude filter hides models whose ID contains a specified string across all providers; include filter (when non-empty) shows only models matching at least one specified string; filters apply in the model picker and the Update Models sheet
+- Automatic config migration: existing configurations with "Custom API slot 1/2" are automatically migrated to the new provider format on first launch; API keys and model presets are preserved
+
 ## v0.58 – 2026-05-02
 - Fix: warning triangle no longer shown for custom OpenAI-compatible providers (local models do not require an API key)
 - History panel: "Open log folder" button added at the bottom — visible when interaction logging is enabled

--- a/Sources/JZLLMContext/Config/AppConfig.swift
+++ b/Sources/JZLLMContext/Config/AppConfig.swift
@@ -69,6 +69,72 @@ struct ModelPreset: Identifiable, Codable, Equatable {
     }
 }
 
+// MARK: - CustomProvider
+
+struct CustomProvider: Codable, Identifiable {
+    var id: UUID
+    var name: String
+    var baseURL: String
+    var apiVersion: String?
+    var tokenParamStyle: TokenParamStyle
+    var requiresAPIKey: Bool
+    var customHeaders: [String: String]
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        baseURL: String,
+        apiVersion: String? = nil,
+        tokenParamStyle: TokenParamStyle = .maxTokens,
+        requiresAPIKey: Bool = false,
+        customHeaders: [String: String] = [:]
+    ) {
+        self.id = id
+        self.name = name
+        self.baseURL = baseURL
+        self.apiVersion = apiVersion
+        self.tokenParamStyle = tokenParamStyle
+        self.requiresAPIKey = requiresAPIKey
+        self.customHeaders = customHeaders
+    }
+}
+
+// MARK: - ProviderType
+
+struct ProviderType: RawRepresentable, Codable, Hashable, Sendable, Identifiable {
+    let rawValue: String
+    var id: String { rawValue }
+
+    init(rawValue: String) { self.rawValue = rawValue }
+    init(_ rawValue: String) { self.rawValue = rawValue }
+
+    static let openai       = ProviderType("openai")
+    static let azureOpenai  = ProviderType("azure_openai")
+    static let azureOpenai2 = ProviderType("azure_openai_2")
+    static let anthropic    = ProviderType("anthropic")
+    static let gemini       = ProviderType("gemini")
+    static let grok         = ProviderType("grok")
+
+    static let builtIn: [ProviderType] = [.openai, .azureOpenai, .azureOpenai2, .anthropic, .gemini, .grok]
+
+    static var allCases: [ProviderType] {
+        builtIn + ConfigStore.shared.config.customProviders
+            .map { ProviderType($0.id.uuidString) }
+    }
+
+    var isCustom: Bool { !Self.builtIn.contains(self) }
+
+    var customProvider: CustomProvider? {
+        ConfigStore.shared.config.customProviders.first { $0.id.uuidString == rawValue }
+    }
+
+    var requiresApiKey: Bool {
+        isCustom ? (customProvider?.requiresAPIKey ?? false) : true
+    }
+}
+
+// MARK: - AppConfig
+
 struct AppConfig: Codable {
     var schemaVersion: Int
     var hotkeyKeyCode: Int
@@ -82,42 +148,53 @@ struct AppConfig: Codable {
     var azureEndpoint2: String?
     var azureDeploymentName2: String?
     var azureAPIVersion2: String?
-    var customOpenAIBaseURL: String?
-    var customOpenAIAPIVersion: String?
-    var customOpenAITokenParam: TokenParamStyle = .maxTokens
-    var customOpenAIBaseURL2: String?
-    var customOpenAIAPIVersion2: String?
-    var customOpenAITokenParam2: TokenParamStyle = .maxTokens
-    var autoCopyAndClose: Bool = false
-    var historyLimit: Int = 5
-    var markdownOutput: Bool = true
-    var modelPresets: [String: [ModelPreset]] = [:]
-    var autoUpdateCheck: Bool = true
-    var appLanguage: AppLanguage = .system
-    var historyLogEnabled: Bool = false
-    var historyLogDirectory: String? = nil
-    var historyLogWarningShown: Bool = false
-    var historyLogFilePrefix: String = ""
-    var sensitiveContentCheckEnabled: Bool = true
-    var customSensitivePatterns: [SensitivePattern] = []
+    // Dynamic custom OpenAI-compatible providers
+    var customProviders: [CustomProvider]
+    var autoCopyAndClose: Bool
+    var historyLimit: Int
+    var markdownOutput: Bool
+    var modelPresets: [String: [ModelPreset]]
+    var autoUpdateCheck: Bool
+    var appLanguage: AppLanguage
+    var historyLogEnabled: Bool
+    var historyLogDirectory: String?
+    var historyLogWarningShown: Bool
+    var historyLogFilePrefix: String
+    var sensitiveContentCheckEnabled: Bool
+    var customSensitivePatterns: [SensitivePattern]
+    // Global model filters
+    var modelExcludeFilters: [String]
+    var modelIncludeFilters: [String]
 
     static let defaultAzureAPIVersion = "2024-10-21"
 
-    init(schemaVersion: Int, hotkeyKeyCode: Int, hotkeyModifiers: Int, actions: [Action],
-         azureEndpoint: String? = nil, azureDeploymentName: String? = nil, azureAPIVersion: String? = nil,
-         azureEndpoint2: String? = nil, azureDeploymentName2: String? = nil, azureAPIVersion2: String? = nil,
-         customOpenAIBaseURL: String? = nil, customOpenAIAPIVersion: String? = nil, customOpenAITokenParam: TokenParamStyle = .maxTokens,
-         customOpenAIBaseURL2: String? = nil, customOpenAIAPIVersion2: String? = nil, customOpenAITokenParam2: TokenParamStyle = .maxTokens,
-         autoCopyAndClose: Bool = false, historyLimit: Int = 5, markdownOutput: Bool = true,
-         modelPresets: [String: [ModelPreset]] = [:],
-         autoUpdateCheck: Bool = true,
-         appLanguage: AppLanguage = .system,
-         historyLogEnabled: Bool = false,
-         historyLogDirectory: String? = nil,
-         historyLogWarningShown: Bool = false,
-         historyLogFilePrefix: String = "",
-         sensitiveContentCheckEnabled: Bool = true,
-         customSensitivePatterns: [SensitivePattern] = []) {
+    init(
+        schemaVersion: Int,
+        hotkeyKeyCode: Int,
+        hotkeyModifiers: Int,
+        actions: [Action],
+        azureEndpoint: String? = nil,
+        azureDeploymentName: String? = nil,
+        azureAPIVersion: String? = nil,
+        azureEndpoint2: String? = nil,
+        azureDeploymentName2: String? = nil,
+        azureAPIVersion2: String? = nil,
+        customProviders: [CustomProvider] = [],
+        autoCopyAndClose: Bool = false,
+        historyLimit: Int = 5,
+        markdownOutput: Bool = true,
+        modelPresets: [String: [ModelPreset]] = [:],
+        autoUpdateCheck: Bool = true,
+        appLanguage: AppLanguage = .system,
+        historyLogEnabled: Bool = false,
+        historyLogDirectory: String? = nil,
+        historyLogWarningShown: Bool = false,
+        historyLogFilePrefix: String = "",
+        sensitiveContentCheckEnabled: Bool = true,
+        customSensitivePatterns: [SensitivePattern] = [],
+        modelExcludeFilters: [String] = [],
+        modelIncludeFilters: [String] = []
+    ) {
         self.schemaVersion = schemaVersion
         self.hotkeyKeyCode = hotkeyKeyCode
         self.hotkeyModifiers = hotkeyModifiers
@@ -128,12 +205,7 @@ struct AppConfig: Codable {
         self.azureEndpoint2 = azureEndpoint2
         self.azureDeploymentName2 = azureDeploymentName2
         self.azureAPIVersion2 = azureAPIVersion2
-        self.customOpenAIBaseURL = customOpenAIBaseURL
-        self.customOpenAIAPIVersion = customOpenAIAPIVersion
-        self.customOpenAITokenParam = customOpenAITokenParam
-        self.customOpenAIBaseURL2 = customOpenAIBaseURL2
-        self.customOpenAIAPIVersion2 = customOpenAIAPIVersion2
-        self.customOpenAITokenParam2 = customOpenAITokenParam2
+        self.customProviders = customProviders
         self.autoCopyAndClose = autoCopyAndClose
         self.historyLimit = historyLimit
         self.markdownOutput = markdownOutput
@@ -146,38 +218,93 @@ struct AppConfig: Codable {
         self.historyLogFilePrefix = historyLogFilePrefix
         self.sensitiveContentCheckEnabled = sensitiveContentCheckEnabled
         self.customSensitivePatterns = customSensitivePatterns
+        self.modelExcludeFilters = modelExcludeFilters
+        self.modelIncludeFilters = modelIncludeFilters
+    }
+
+    // Legacy decode-only keys (schemaVersion < 2)
+    private enum LegacyCodingKeys: String, CodingKey {
+        case customOpenAIBaseURL, customOpenAIAPIVersion, customOpenAITokenParam
+        case customOpenAIBaseURL2, customOpenAIAPIVersion2, customOpenAITokenParam2
     }
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        schemaVersion = try c.decode(Int.self, forKey: .schemaVersion)
-        hotkeyKeyCode = try c.decode(Int.self, forKey: .hotkeyKeyCode)
-        hotkeyModifiers = try c.decode(Int.self, forKey: .hotkeyModifiers)
-        actions = try c.decode([Action].self, forKey: .actions)
-        azureEndpoint = try c.decodeIfPresent(String.self, forKey: .azureEndpoint)
-        azureDeploymentName = try c.decodeIfPresent(String.self, forKey: .azureDeploymentName)
-        azureAPIVersion = try c.decodeIfPresent(String.self, forKey: .azureAPIVersion)
-        azureEndpoint2 = try c.decodeIfPresent(String.self, forKey: .azureEndpoint2)
+        schemaVersion        = try c.decode(Int.self, forKey: .schemaVersion)
+        hotkeyKeyCode        = try c.decode(Int.self, forKey: .hotkeyKeyCode)
+        hotkeyModifiers      = try c.decode(Int.self, forKey: .hotkeyModifiers)
+        actions              = try c.decode([Action].self, forKey: .actions)
+        azureEndpoint        = try c.decodeIfPresent(String.self, forKey: .azureEndpoint)
+        azureDeploymentName  = try c.decodeIfPresent(String.self, forKey: .azureDeploymentName)
+        azureAPIVersion      = try c.decodeIfPresent(String.self, forKey: .azureAPIVersion)
+        azureEndpoint2       = try c.decodeIfPresent(String.self, forKey: .azureEndpoint2)
         azureDeploymentName2 = try c.decodeIfPresent(String.self, forKey: .azureDeploymentName2)
-        azureAPIVersion2 = try c.decodeIfPresent(String.self, forKey: .azureAPIVersion2)
-        customOpenAIBaseURL = try c.decodeIfPresent(String.self, forKey: .customOpenAIBaseURL)
-        customOpenAIAPIVersion = try c.decodeIfPresent(String.self, forKey: .customOpenAIAPIVersion)
-        customOpenAITokenParam = try c.decodeIfPresent(TokenParamStyle.self, forKey: .customOpenAITokenParam) ?? .maxTokens
-        customOpenAIBaseURL2 = try c.decodeIfPresent(String.self, forKey: .customOpenAIBaseURL2)
-        customOpenAIAPIVersion2 = try c.decodeIfPresent(String.self, forKey: .customOpenAIAPIVersion2)
-        customOpenAITokenParam2 = try c.decodeIfPresent(TokenParamStyle.self, forKey: .customOpenAITokenParam2) ?? .maxTokens
-        autoCopyAndClose = try c.decodeIfPresent(Bool.self, forKey: .autoCopyAndClose) ?? false
-        historyLimit = try c.decodeIfPresent(Int.self, forKey: .historyLimit) ?? 5
-        markdownOutput = try c.decodeIfPresent(Bool.self, forKey: .markdownOutput) ?? true
-        modelPresets = try c.decodeIfPresent([String: [ModelPreset]].self, forKey: .modelPresets) ?? [:]
-        autoUpdateCheck = try c.decodeIfPresent(Bool.self, forKey: .autoUpdateCheck) ?? true
-        appLanguage = try c.decodeIfPresent(AppLanguage.self, forKey: .appLanguage) ?? .system
-        historyLogEnabled = try c.decodeIfPresent(Bool.self, forKey: .historyLogEnabled) ?? false
-        historyLogDirectory = try c.decodeIfPresent(String.self, forKey: .historyLogDirectory)
+        azureAPIVersion2     = try c.decodeIfPresent(String.self, forKey: .azureAPIVersion2)
+        customProviders      = try c.decodeIfPresent([CustomProvider].self, forKey: .customProviders) ?? []
+        autoCopyAndClose     = try c.decodeIfPresent(Bool.self, forKey: .autoCopyAndClose) ?? false
+        historyLimit         = try c.decodeIfPresent(Int.self, forKey: .historyLimit) ?? 5
+        markdownOutput       = try c.decodeIfPresent(Bool.self, forKey: .markdownOutput) ?? true
+        modelPresets         = try c.decodeIfPresent([String: [ModelPreset]].self, forKey: .modelPresets) ?? [:]
+        autoUpdateCheck      = try c.decodeIfPresent(Bool.self, forKey: .autoUpdateCheck) ?? true
+        appLanguage          = try c.decodeIfPresent(AppLanguage.self, forKey: .appLanguage) ?? .system
+        historyLogEnabled    = try c.decodeIfPresent(Bool.self, forKey: .historyLogEnabled) ?? false
+        historyLogDirectory  = try c.decodeIfPresent(String.self, forKey: .historyLogDirectory)
         historyLogWarningShown = try c.decodeIfPresent(Bool.self, forKey: .historyLogWarningShown) ?? false
         historyLogFilePrefix = try c.decodeIfPresent(String.self, forKey: .historyLogFilePrefix) ?? ""
         sensitiveContentCheckEnabled = try c.decodeIfPresent(Bool.self, forKey: .sensitiveContentCheckEnabled) ?? true
         customSensitivePatterns = try c.decodeIfPresent([SensitivePattern].self, forKey: .customSensitivePatterns) ?? []
+        modelExcludeFilters  = try c.decodeIfPresent([String].self, forKey: .modelExcludeFilters) ?? []
+        modelIncludeFilters  = try c.decodeIfPresent([String].self, forKey: .modelIncludeFilters) ?? []
+
+        // Migrate schemaVersion 1 → 2: convert flat custom OpenAI fields to CustomProvider list
+        if schemaVersion < 2 {
+            let lc = try decoder.container(keyedBy: LegacyCodingKeys.self)
+            let url1   = try lc.decodeIfPresent(String.self, forKey: .customOpenAIBaseURL)
+            let ver1   = try lc.decodeIfPresent(String.self, forKey: .customOpenAIAPIVersion)
+            let tok1   = try lc.decodeIfPresent(TokenParamStyle.self, forKey: .customOpenAITokenParam) ?? .maxTokens
+            let url2   = try lc.decodeIfPresent(String.self, forKey: .customOpenAIBaseURL2)
+            let ver2   = try lc.decodeIfPresent(String.self, forKey: .customOpenAIAPIVersion2)
+            let tok2   = try lc.decodeIfPresent(TokenParamStyle.self, forKey: .customOpenAITokenParam2) ?? .maxTokens
+
+            var migrated: [CustomProvider] = customProviders
+            var oldToNew: [String: String] = [:]  // old rawValue → new UUID string
+
+            if let url = url1, !url.isEmpty {
+                let cp = CustomProvider(name: L("provider.custom1"), baseURL: url,
+                                        apiVersion: ver1, tokenParamStyle: tok1)
+                migrated.append(cp)
+                oldToNew["custom_openai"] = cp.id.uuidString
+                // Copy Keychain entry to new UUID-based key
+                if let key = KeychainStore.loadRaw(account: "jzllmcontext.custom_openai.apikey") {
+                    KeychainStore.saveRaw(key, account: "jzllmcontext.\(cp.id.uuidString).apikey")
+                }
+            }
+            if let url = url2, !url.isEmpty {
+                let cp = CustomProvider(name: L("provider.custom2"), baseURL: url,
+                                        apiVersion: ver2, tokenParamStyle: tok2)
+                migrated.append(cp)
+                oldToNew["custom_openai_2"] = cp.id.uuidString
+                if let key = KeychainStore.loadRaw(account: "jzllmcontext.custom_openai_2.apikey") {
+                    KeychainStore.saveRaw(key, account: "jzllmcontext.\(cp.id.uuidString).apikey")
+                }
+            }
+
+            // Update action provider references and modelPresets keys
+            if !oldToNew.isEmpty {
+                actions = actions.map { action in
+                    var a = action
+                    if let newID = oldToNew[action.provider.rawValue] {
+                        a.provider = ProviderType(newID)
+                    }
+                    return a
+                }
+                for (oldKey, newKey) in oldToNew where modelPresets[oldKey] != nil {
+                    modelPresets[newKey] = modelPresets.removeValue(forKey: oldKey)
+                }
+            }
+            customProviders = migrated
+            schemaVersion = 2
+        }
     }
 
     static var `default`: AppConfig { makeDefault() }
@@ -193,7 +320,7 @@ struct AppConfig: Codable {
         case .es: code = "es"
         }
         return AppConfig(
-            schemaVersion: 1,
+            schemaVersion: 2,
             hotkeyKeyCode: Int(kVK_Space),
             hotkeyModifiers: Int(cmdKey | shiftKey),
             actions: defaultActions(forLang: code),
@@ -330,16 +457,74 @@ struct Action: Codable, Identifiable, Hashable, Equatable {
 
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        id = try c.decode(UUID.self, forKey: .id)
-        name = try c.decode(String.self, forKey: .name)
-        systemPrompt = try c.decode(String.self, forKey: .systemPrompt)
-        provider = try c.decode(ProviderType.self, forKey: .provider)
-        model = try c.decode(String.self, forKey: .model)
-        enabled = try c.decode(Bool.self, forKey: .enabled)
-        temperature = try c.decodeIfPresent(Double.self, forKey: .temperature) ?? 0.7
-        maxTokens = try c.decodeIfPresent(Int.self, forKey: .maxTokens) ?? 2048
+        id            = try c.decode(UUID.self, forKey: .id)
+        name          = try c.decode(String.self, forKey: .name)
+        systemPrompt  = try c.decode(String.self, forKey: .systemPrompt)
+        provider      = try c.decode(ProviderType.self, forKey: .provider)
+        model         = try c.decode(String.self, forKey: .model)
+        enabled       = try c.decode(Bool.self, forKey: .enabled)
+        temperature   = try c.decodeIfPresent(Double.self, forKey: .temperature) ?? 0.7
+        maxTokens     = try c.decodeIfPresent(Int.self, forKey: .maxTokens) ?? 2048
         autoCopyClose = try c.decodeIfPresent(AutoCopyClose.self, forKey: .autoCopyClose) ?? .useGlobal
-        isDefault = try c.decodeIfPresent(Bool.self, forKey: .isDefault) ?? false
+        isDefault     = try c.decodeIfPresent(Bool.self, forKey: .isDefault) ?? false
+    }
+}
+
+// MARK: - ProviderType model helpers
+
+extension ProviderType {
+    func effectiveModels() -> [ModelPreset] {
+        let cfg = ConfigStore.shared.config
+        let stored = cfg.modelPresets[rawValue] ?? []
+        var result = stored.isEmpty ? presetModels : stored
+        if !cfg.modelIncludeFilters.isEmpty {
+            result = result.filter { p in
+                cfg.modelIncludeFilters.contains { p.id.lowercased().contains($0.lowercased()) }
+            }
+        }
+        if !cfg.modelExcludeFilters.isEmpty {
+            result = result.filter { p in
+                !cfg.modelExcludeFilters.contains { p.id.lowercased().contains($0.lowercased()) }
+            }
+        }
+        return result
+    }
+
+    var presetModels: [ModelPreset] {
+        if self == .openai {
+            return [
+                .init(id: "gpt-5.5",      displayName: "gpt-5.5",             isRecommended: true),
+                .init(id: "gpt-5.4-mini", displayName: "gpt-5.4-mini"),
+                .init(id: "o4-mini",      displayName: "o4-mini (legacy)"),
+                .init(id: "o3",           displayName: "o3 (legacy)"),
+                .init(id: "o3-mini",      displayName: "o3-mini (legacy)"),
+                .init(id: "gpt-4o",       displayName: "gpt-4o (legacy)"),
+                .init(id: "gpt-4o-mini",  displayName: "gpt-4o-mini (legacy)")
+            ]
+        }
+        if self == .anthropic {
+            return [
+                .init(id: "claude-sonnet-4-6",        displayName: "claude-sonnet-4.6", isRecommended: true),
+                .init(id: "claude-opus-4-7",           displayName: "claude-opus-4.7"),
+                .init(id: "claude-haiku-4-5-20251001", displayName: "claude-haiku-4.5")
+            ]
+        }
+        if self == .gemini {
+            return [
+                .init(id: "gemini-3.1-pro",         displayName: "gemini-3.1-pro",         isRecommended: true),
+                .init(id: "gemini-3-flash-preview",  displayName: "gemini-3-flash-preview"),
+                .init(id: "gemini-3.1-flash-lite",   displayName: "gemini-3.1-flash-lite")
+            ]
+        }
+        if self == .grok {
+            return [
+                .init(id: "grok-4.20",               displayName: "grok-4.20",               isRecommended: true),
+                .init(id: "grok-4.20-non-reasoning",  displayName: "grok-4.20-non-reasoning"),
+                .init(id: "grok-4-1-fast-reasoning",  displayName: "grok-4.1-fast-reasoning")
+            ]
+        }
+        // azureOpenai, azureOpenai2, custom providers
+        return []
     }
 }
 
@@ -353,24 +538,6 @@ enum AutoCopyClose: String, Codable, CaseIterable {
         case .useGlobal: L("autocopy.use_global")
         case .always:    L("autocopy.always")
         case .never:     L("autocopy.never")
-        }
-    }
-}
-
-enum ProviderType: String, Codable, CaseIterable {
-    case openai
-    case azureOpenai = "azure_openai"
-    case azureOpenai2 = "azure_openai_2"
-    case anthropic
-    case gemini
-    case grok
-    case customOpenAI = "custom_openai"
-    case customOpenAI2 = "custom_openai_2"
-
-    var requiresApiKey: Bool {
-        switch self {
-        case .customOpenAI, .customOpenAI2: return false
-        default: return true
         }
     }
 }

--- a/Sources/JZLLMContext/Config/ConnectionTester.swift
+++ b/Sources/JZLLMContext/Config/ConnectionTester.swift
@@ -2,15 +2,25 @@ import Foundation
 
 enum ConnectionTester {
     static func test(for provider: ProviderType) async throws {
-        switch provider {
-        case .openai:       try await pingOpenAI()
-        case .anthropic:    try await pingAnthropic()
-        case .gemini:       try await pingGemini()
-        case .grok:         try await pingGrok()
-        case .azureOpenai:  try await pingAzure(slot: 1)
-        case .azureOpenai2: try await pingAzure(slot: 2)
-        case .customOpenAI:  try await pingCustom(slot: 1)
-        case .customOpenAI2: try await pingCustom(slot: 2)
+        if provider == .openai {
+            try await pingOpenAI()
+        } else if provider == .anthropic {
+            try await pingAnthropic()
+        } else if provider == .gemini {
+            try await pingGemini()
+        } else if provider == .grok {
+            try await pingGrok()
+        } else if provider == .azureOpenai {
+            try await pingAzure(slot: 1)
+        } else if provider == .azureOpenai2 {
+            try await pingAzure(slot: 2)
+        } else if provider.isCustom {
+            guard let cp = provider.customProvider else {
+                throw LLMError.missingAPIKey(provider)
+            }
+            try await pingCustom(provider: provider, config: cp)
+        } else {
+            throw LLMError.missingAPIKey(provider)
         }
     }
 
@@ -88,23 +98,21 @@ enum ConnectionTester {
 
     // MARK: - Custom OpenAI-compatible
 
-    private static func pingCustom(slot: Int) async throws {
-        let providerType: ProviderType = slot == 1 ? .customOpenAI : .customOpenAI2
-        let key = (try? KeychainStore.load(for: providerType)) ?? ""
-        let config = ConfigStore.shared.config
-        let urlStr = slot == 1 ? config.customOpenAIBaseURL : config.customOpenAIBaseURL2
-        guard let urlStr, !urlStr.isEmpty else {
-            throw LLMError.missingAPIKey(providerType)
+    private static func pingCustom(provider: ProviderType, config cp: CustomProvider) async throws {
+        let key = (try? KeychainStore.load(for: provider)) ?? ""
+        guard !cp.baseURL.isEmpty else {
+            throw LLMError.missingAPIKey(provider)
         }
-        var base = urlStr.hasSuffix("/") ? String(urlStr.dropLast()) : urlStr
+        var base = cp.baseURL.hasSuffix("/") ? String(cp.baseURL.dropLast()) : cp.baseURL
         if base.hasSuffix("/chat/completions") {
             base = String(base.dropLast("/chat/completions".count))
         }
         guard let modelsURL = URL(string: "\(base)/models") else {
-            throw LLMError.missingAPIKey(providerType)
+            throw LLMError.missingAPIKey(provider)
         }
         var req = URLRequest(url: modelsURL)
         if !key.isEmpty { req.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization") }
+        for (k, v) in cp.customHeaders { req.setValue(v, forHTTPHeaderField: k) }
         req.timeoutInterval = 10
         let (data, response) = try await URLSession.shared.data(for: req)
         try validate(data: data, response: response)

--- a/Sources/JZLLMContext/Config/KeychainStore.swift
+++ b/Sources/JZLLMContext/Config/KeychainStore.swift
@@ -63,6 +63,36 @@ enum KeychainStore {
         ]
         SecItemDelete(query as CFDictionary)
     }
+
+    // Raw account-string helpers used during schema migration
+    static func loadRaw(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func saveRaw(_ key: String, account: String) {
+        let data = Data(key.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        let attributes: [String: Any] = [kSecValueData as String: data]
+        if SecItemUpdate(query as CFDictionary, attributes as CFDictionary) == errSecItemNotFound {
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            SecItemAdd(addQuery as CFDictionary, nil)
+        }
+    }
 }
 
 enum KeychainError: Error, LocalizedError {

--- a/Sources/JZLLMContext/Config/ModelFetcher.swift
+++ b/Sources/JZLLMContext/Config/ModelFetcher.swift
@@ -31,13 +31,19 @@ enum ModelFetcher {
     ]
 
     static func fetch(for provider: ProviderType) async throws -> [FetchedModel] {
-        switch provider {
-        case .openai:                    return try await fetchOpenAI()
-        case .anthropic:                 return try await fetchAnthropic()
-        case .gemini:                    return try await fetchGemini()
-        case .grok:                      return try await fetchGrok()
-        case .customOpenAI, .customOpenAI2: return try await fetchCustomOpenAI(provider: provider)
-        default:                         throw ModelFetchError.invalidResponse
+        if provider == .openai {
+            return try await fetchOpenAI()
+        } else if provider == .anthropic {
+            return try await fetchAnthropic()
+        } else if provider == .gemini {
+            return try await fetchGemini()
+        } else if provider == .grok {
+            return try await fetchGrok()
+        } else if provider.isCustom {
+            guard let cp = provider.customProvider else { throw ModelFetchError.missingBaseURL }
+            return try await fetchCustomOpenAI(provider: provider, config: cp)
+        } else {
+            throw ModelFetchError.invalidResponse
         }
     }
 
@@ -192,15 +198,11 @@ enum ModelFetcher {
         return models
     }
 
-    // MARK: - Custom OpenAI
+    // MARK: - Custom OpenAI-compatible
 
-    private static func fetchCustomOpenAI(provider: ProviderType) async throws -> [FetchedModel] {
-        let cfg = ConfigStore.shared.config
-        let rawURL = provider == .customOpenAI ? cfg.customOpenAIBaseURL : cfg.customOpenAIBaseURL2
-        guard let baseURL = rawURL, !baseURL.isEmpty else {
-            throw ModelFetchError.missingBaseURL
-        }
-        let base = baseURL.hasSuffix("/") ? String(baseURL.dropLast()) : baseURL
+    private static func fetchCustomOpenAI(provider: ProviderType, config cp: CustomProvider) async throws -> [FetchedModel] {
+        guard !cp.baseURL.isEmpty else { throw ModelFetchError.missingBaseURL }
+        let base = cp.baseURL.hasSuffix("/") ? String(cp.baseURL.dropLast()) : cp.baseURL
         guard let url = URL(string: "\(base)/models") else {
             throw ModelFetchError.invalidResponse
         }
@@ -209,6 +211,7 @@ enum ModelFetcher {
         if let key = try? KeychainStore.load(for: provider), !key.isEmpty {
             request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
         }
+        for (k, v) in cp.customHeaders { request.setValue(v, forHTTPHeaderField: k) }
 
         let (data, response) = try await URLSession.shared.data(for: request)
         guard (response as? HTTPURLResponse)?.statusCode == 200 else {

--- a/Sources/JZLLMContext/Providers/LLMProvider.swift
+++ b/Sources/JZLLMContext/Providers/LLMProvider.swift
@@ -12,20 +12,18 @@ enum LLMError: Error, LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .missingAPIKey(let provider):
-            switch provider {
-            case .customOpenAI:   "Chybí Base URL pro Vlastní API (slot 1). Nakonfiguruj ho v Nastavení → Providery."
-            case .customOpenAI2:  "Chybí Base URL pro Vlastní API (slot 2). Nakonfiguruj ho v Nastavení → Providery."
-            case .openai:         "Chybí API klíč pro OpenAI. Přidej ho v Nastavení → Providery."
-            case .azureOpenai:    "Chybí API klíč nebo konfigurace pro Azure AI (slot 1). Přidej ho v Nastavení → Providery."
-            case .azureOpenai2:   "Chybí API klíč nebo konfigurace pro Azure AI (slot 2). Přidej ho v Nastavení → Providery."
-            case .anthropic:      "Chybí API klíč pro Anthropic. Přidej ho v Nastavení → Providery."
-            case .gemini:         "Chybí API klíč pro Google Gemini. Přidej ho v Nastavení → Providery."
-            case .grok:           "Chybí API klíč pro xAI Grok. Přidej ho v Nastavení → Providery."
-            }
-        case .httpError(let code, let message): "API chyba \(code): \(message)"
-        case .networkError(let error): "Síťová chyba: \(error.localizedDescription)"
-        case .decodingError: "Chyba při zpracování odpovědi"
+        case .missingAPIKey(let p):
+            if p == .openai      { return "Chybí API klíč pro OpenAI. Přidej ho v Nastavení → Providery." }
+            if p == .azureOpenai  { return "Chybí API klíč nebo konfigurace pro Azure AI (slot 1). Přidej ho v Nastavení → Providery." }
+            if p == .azureOpenai2 { return "Chybí API klíč nebo konfigurace pro Azure AI (slot 2). Přidej ho v Nastavení → Providery." }
+            if p == .anthropic    { return "Chybí API klíč pro Anthropic. Přidej ho v Nastavení → Providery." }
+            if p == .gemini       { return "Chybí API klíč pro Google Gemini. Přidej ho v Nastavení → Providery." }
+            if p == .grok         { return "Chybí API klíč pro xAI Grok. Přidej ho v Nastavení → Providery." }
+            let name = p.customProvider?.name ?? p.rawValue
+            return "Chybí konfigurace pro \(name). Nakonfiguruj ho v Nastavení → Providery."
+        case .httpError(let code, let message): return "API chyba \(code): \(message)"
+        case .networkError(let error): return "Síťová chyba: \(error.localizedDescription)"
+        case .decodingError: return "Chyba při zpracování odpovědi"
         }
     }
 }

--- a/Sources/JZLLMContext/Providers/OpenAIProvider.swift
+++ b/Sources/JZLLMContext/Providers/OpenAIProvider.swift
@@ -13,13 +13,15 @@ struct OpenAIProvider: LLMProvider {
     let temperature: Double
     let maxTokens: Int
     let tokenParamStyle: TokenParamStyle
+    let extraHeaders: [String: String]
 
     init(model: String, apiKey: String,
          baseURL: URL = URL(string: "https://api.openai.com/v1")!,
          chatURL: URL? = nil,
          authStyle: OpenAIAuthStyle = .bearer,
          temperature: Double = 0.7, maxTokens: Int = 4096,
-         tokenParamStyle: TokenParamStyle = .maxCompletionTokens) {
+         tokenParamStyle: TokenParamStyle = .maxCompletionTokens,
+         extraHeaders: [String: String] = [:]) {
         self.model = model
         self.apiKey = apiKey
         self.chatURL = chatURL ?? baseURL.appendingPathComponent("chat/completions")
@@ -27,6 +29,7 @@ struct OpenAIProvider: LLMProvider {
         self.temperature = temperature
         self.maxTokens = maxTokens
         self.tokenParamStyle = tokenParamStyle
+        self.extraHeaders = extraHeaders
     }
 
     func stream(systemPrompt: String, userContent: String) -> AsyncThrowingStream<String, Error> {
@@ -40,6 +43,9 @@ struct OpenAIProvider: LLMProvider {
                     case .apiKey: request.setValue(apiKey, forHTTPHeaderField: "api-key")
                     }
                     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    for (key, value) in extraHeaders {
+                        request.setValue(value, forHTTPHeaderField: key)
+                    }
                     request.timeoutInterval = 60
 
                     let body = OpenAIChatRequest(

--- a/Sources/JZLLMContext/Providers/ProviderFactory.swift
+++ b/Sources/JZLLMContext/Providers/ProviderFactory.swift
@@ -2,15 +2,16 @@ import Foundation
 
 enum ProviderFactory {
     static func make(for action: Action) throws -> any LLMProvider {
-        switch action.provider {
-        case .openai:
+        let provider = action.provider
+
+        if provider == .openai {
             guard let apiKey = try? KeychainStore.load(for: .openai) else {
                 throw LLMError.missingAPIKey(.openai)
             }
             return OpenAIProvider(model: action.model, apiKey: apiKey, temperature: action.temperature,
                                   maxTokens: action.maxTokens, tokenParamStyle: .maxCompletionTokens)
 
-        case .azureOpenai:
+        } else if provider == .azureOpenai {
             guard let apiKey = try? KeychainStore.load(for: .azureOpenai) else {
                 throw LLMError.missingAPIKey(.azureOpenai)
             }
@@ -25,7 +26,7 @@ enum ProviderFactory {
                                   authStyle: .apiKey, temperature: action.temperature,
                                   maxTokens: action.maxTokens, tokenParamStyle: .maxCompletionTokens)
 
-        case .azureOpenai2:
+        } else if provider == .azureOpenai2 {
             guard let apiKey = try? KeychainStore.load(for: .azureOpenai2) else {
                 throw LLMError.missingAPIKey(.azureOpenai2)
             }
@@ -33,20 +34,21 @@ enum ProviderFactory {
             guard let endpointStr = config.azureEndpoint2, !endpointStr.isEmpty else {
                 throw LLMError.missingAPIKey(.azureOpenai2)
             }
-            let chatURL2 = try azureChatURL(deploymentBase: endpointStr,
-                                            legacyDeployment: config.azureDeploymentName2,
-                                            apiVersion: config.azureAPIVersion2 ?? AppConfig.defaultAzureAPIVersion)
-            return OpenAIProvider(model: action.model, apiKey: apiKey, chatURL: chatURL2,
+            let chatURL = try azureChatURL(deploymentBase: endpointStr,
+                                           legacyDeployment: config.azureDeploymentName2,
+                                           apiVersion: config.azureAPIVersion2 ?? AppConfig.defaultAzureAPIVersion)
+            return OpenAIProvider(model: action.model, apiKey: apiKey, chatURL: chatURL,
                                   authStyle: .apiKey, temperature: action.temperature,
                                   maxTokens: action.maxTokens, tokenParamStyle: .maxCompletionTokens)
 
-        case .anthropic:
+        } else if provider == .anthropic {
             guard let apiKey = try? KeychainStore.load(for: .anthropic) else {
                 throw LLMError.missingAPIKey(.anthropic)
             }
-            return AnthropicProvider(model: action.model, apiKey: apiKey, temperature: action.temperature, maxTokens: action.maxTokens)
+            return AnthropicProvider(model: action.model, apiKey: apiKey, temperature: action.temperature,
+                                     maxTokens: action.maxTokens)
 
-        case .gemini:
+        } else if provider == .gemini {
             guard let apiKey = try? KeychainStore.load(for: .gemini) else {
                 throw LLMError.missingAPIKey(.gemini)
             }
@@ -55,7 +57,7 @@ enum ProviderFactory {
                                   authStyle: .bearer, temperature: action.temperature,
                                   maxTokens: action.maxTokens, tokenParamStyle: .maxTokens)
 
-        case .grok:
+        } else if provider == .grok {
             guard let apiKey = try? KeychainStore.load(for: .grok) else {
                 throw LLMError.missingAPIKey(.grok)
             }
@@ -64,33 +66,25 @@ enum ProviderFactory {
                                   authStyle: .bearer, temperature: action.temperature,
                                   maxTokens: action.maxTokens, tokenParamStyle: .maxTokens)
 
-        case .customOpenAI:
-            let apiKey = (try? KeychainStore.load(for: .customOpenAI)) ?? ""
-            let config = ConfigStore.shared.config
-            guard let urlStr = config.customOpenAIBaseURL, !urlStr.isEmpty else {
-                throw LLMError.missingAPIKey(.customOpenAI)
+        } else if provider.isCustom {
+            guard let cp = provider.customProvider else {
+                throw LLMError.missingAPIKey(provider)
             }
-            let chatURL = try customChatURL(baseURLStr: urlStr, apiVersion: config.customOpenAIAPIVersion, slot: .customOpenAI)
+            guard !cp.baseURL.isEmpty else {
+                throw LLMError.missingAPIKey(provider)
+            }
+            let apiKey = (try? KeychainStore.load(for: provider)) ?? ""
+            let chatURL = try customChatURL(baseURLStr: cp.baseURL, apiVersion: cp.apiVersion, provider: provider)
             return OpenAIProvider(model: action.model, apiKey: apiKey, chatURL: chatURL,
                                   authStyle: .bearer, temperature: action.temperature,
-                                  maxTokens: action.maxTokens, tokenParamStyle: config.customOpenAITokenParam)
-
-        case .customOpenAI2:
-            let apiKey = (try? KeychainStore.load(for: .customOpenAI2)) ?? ""
-            let config = ConfigStore.shared.config
-            guard let urlStr = config.customOpenAIBaseURL2, !urlStr.isEmpty else {
-                throw LLMError.missingAPIKey(.customOpenAI2)
-            }
-            let chatURL2 = try customChatURL(baseURLStr: urlStr, apiVersion: config.customOpenAIAPIVersion2, slot: .customOpenAI2)
-            return OpenAIProvider(model: action.model, apiKey: apiKey, chatURL: chatURL2,
-                                  authStyle: .bearer, temperature: action.temperature,
-                                  maxTokens: action.maxTokens, tokenParamStyle: config.customOpenAITokenParam2)
+                                  maxTokens: action.maxTokens, tokenParamStyle: cp.tokenParamStyle,
+                                  extraHeaders: cp.customHeaders)
         }
+
+        throw LLMError.missingAPIKey(provider)
     }
 
-    /// Builds the chat/completions URL for a custom OpenAI-compatible provider.
-    /// Appends /chat/completions if not already present, and optionally ?api-version=…
-    private static func customChatURL(baseURLStr: String, apiVersion: String?, slot: ProviderType) throws -> URL {
+    private static func customChatURL(baseURLStr: String, apiVersion: String?, provider: ProviderType) throws -> URL {
         var base = baseURLStr.hasSuffix("/") ? String(baseURLStr.dropLast()) : baseURLStr
         if !base.hasSuffix("/chat/completions") {
             base += "/chat/completions"
@@ -98,26 +92,20 @@ enum ProviderFactory {
         if let version = apiVersion, !version.isEmpty {
             var components = URLComponents(string: base)
             components?.queryItems = [URLQueryItem(name: "api-version", value: version)]
-            guard let url = components?.url else { throw LLMError.missingAPIKey(slot) }
+            guard let url = components?.url else { throw LLMError.missingAPIKey(provider) }
             return url
         }
-        guard let url = URL(string: base) else { throw LLMError.missingAPIKey(slot) }
+        guard let url = URL(string: base) else { throw LLMError.missingAPIKey(provider) }
         return url
     }
 
-    /// Builds the full chat/completions URL for an Azure deployment.
-    /// If `deploymentBase` already contains "/deployments/" or "/chat/completions", use it directly.
-    /// Otherwise fall back to legacy endpoint+deploymentName concatenation.
     private static func azureChatURL(deploymentBase: String, legacyDeployment: String?, apiVersion: String) throws -> URL {
         var base = deploymentBase.hasSuffix("/") ? String(deploymentBase.dropLast()) : deploymentBase
 
-        // Strip trailing /chat/completions so we can re-add it uniformly
         if base.hasSuffix("/chat/completions") {
             base = String(base.dropLast("/chat/completions".count))
         }
 
-        // If the user provided only the resource endpoint (no /deployments/ path),
-        // fall back to legacy auto-construction using the separate deployment name field.
         if !base.contains("/deployments/") {
             guard let dep = legacyDeployment, !dep.isEmpty else {
                 throw LLMError.missingAPIKey(.azureOpenai)

--- a/Sources/JZLLMContext/Resources/Localizable.xcstrings
+++ b/Sources/JZLLMContext/Resources/Localizable.xcstrings
@@ -1282,6 +1282,143 @@
       }
     },
 
+    "settings.providers.custom.name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Název" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Name" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Nombre" } }
+      }
+    },
+    "settings.providers.custom.new_name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nový provider" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "New Provider" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Nuevo proveedor" } }
+      }
+    },
+    "settings.providers.custom.unnamed" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nepojmenovaný provider" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Unnamed Provider" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Proveedor sin nombre" } }
+      }
+    },
+    "settings.providers.custom.requires_key" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Vyžaduje API klíč" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Requires API key" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Requiere clave API" } }
+      }
+    },
+    "settings.providers.custom.headers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Vlastní HTTP hlavičky" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Custom HTTP headers" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Cabeceras HTTP personalizadas" } }
+      }
+    },
+    "settings.providers.custom.header_key" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Název" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Header name" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Nombre" } }
+      }
+    },
+    "settings.providers.custom.header_value" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Hodnota" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Value" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Valor" } }
+      }
+    },
+    "settings.providers.custom.delete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Odebrat provider" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove provider" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Eliminar proveedor" } }
+      }
+    },
+    "settings.providers.custom.delete_confirm_title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Odebrat provider?" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove provider?" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "¿Eliminar proveedor?" } }
+      }
+    },
+    "settings.providers.custom.delete_confirm_message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Odebere provider „%@" včetně API klíče. Akce používající tento provider budou přepnuty na OpenAI." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "This will remove provider \"%@\" and its API key. Actions using this provider will be reset to OpenAI." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Se eliminará el proveedor \"%@\" y su clave API. Las acciones que usen este proveedor se restablecerán a OpenAI." } }
+      }
+    },
+    "settings.providers.add_custom" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Přidat vlastní provider" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Add custom provider" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Añadir proveedor personalizado" } }
+      }
+    },
+    "settings.providers.model_filters" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Filtr modelů" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Model filters" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Filtros de modelos" } }
+      }
+    },
+    "settings.providers.model_exclude_filter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Skrýt obsahující" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Hide containing" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Ocultar si contiene" } }
+      }
+    },
+    "settings.providers.model_include_filter" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Zobrazit pouze obsahující" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Show only containing" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Mostrar solo si contiene" } }
+      }
+    },
+    "settings.providers.model_filter.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "např. preview" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "e.g. preview" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "p.ej. preview" } }
+      }
+    },
+    "settings.providers.model_filter.hint_exclude" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Skryje modely jejichž ID obsahuje daný řetězec (u všech providerů)." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Hides models whose ID contains the given string (across all providers)." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Oculta modelos cuyo ID contiene la cadena dada (en todos los proveedores)." } }
+      }
+    },
+    "settings.providers.model_filter.hint_include" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Zobrazí pouze modely jejichž ID obsahuje alespoň jeden z řetězců (má přednost před exclude filtrem)." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Shows only models whose ID contains at least one of the strings (takes priority over exclude filter)." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Muestra solo modelos cuyo ID contiene al menos una de las cadenas (tiene prioridad sobre el filtro de exclusión)." } }
+      }
+    },
+
     "autocopy.use_global" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -1340,6 +1477,22 @@
       }
     },
 
+    "common.add" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Přidat" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Add" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Añadir" } }
+      }
+    },
+    "common.delete" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Smazat" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Delete" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Eliminar" } }
+      }
+    },
     "common.cancel" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/JZLLMContext/UI/SettingsView.swift
+++ b/Sources/JZLLMContext/UI/SettingsView.swift
@@ -19,8 +19,7 @@ struct SettingsView: View {
     @State private var grokKey = ""
     @State private var azureKey = ""
     @State private var azureKey2 = ""
-    @State private var customKey = ""
-    @State private var customKey2 = ""
+    @State private var customProviderKeys: [String: String] = [:]
     @State private var keySaveStatus: [ProviderType: Bool] = [:]
     @State private var launchAtLogin = false
     @State private var importedActions: [Action] = []
@@ -40,6 +39,13 @@ struct SettingsView: View {
     @State private var updateState: UpdateState = .idle
     @State private var newPatternLabel = ""
     @State private var newPatternRegex = ""
+    @State private var newExcludeFilter = ""
+    @State private var newIncludeFilter = ""
+    @State private var newHeaderKey: [UUID: String] = [:]
+    @State private var newHeaderValue: [UUID: String] = [:]
+    @State private var showDeleteProviderAlert = false
+    @State private var providerToDelete: CustomProvider? = nil
+
     private enum PatternField: Hashable { case label, regex }
     @FocusState private var patternFocus: PatternField?
 
@@ -76,7 +82,18 @@ struct SettingsView: View {
                 reviewingProvider = nil
             }
         }
+        .alert(L("settings.providers.custom.delete_confirm_title"), isPresented: $showDeleteProviderAlert) {
+            Button(L("common.delete"), role: .destructive) {
+                if let cp = providerToDelete { performDeleteCustomProvider(cp) }
+            }
+            Button(L("common.cancel"), role: .cancel) { providerToDelete = nil }
+        } message: {
+            Text(String(format: L("settings.providers.custom.delete_confirm_message"),
+                        providerToDelete?.name ?? ""))
+        }
     }
+
+    // MARK: - General Tab
 
     private var generalTab: some View {
         Form {
@@ -355,52 +372,7 @@ struct SettingsView: View {
         }
     }
 
-    private func isValidRegex(_ pattern: String) -> Bool {
-        !pattern.isEmpty && (try? NSRegularExpression(pattern: pattern)) != nil
-    }
-
-    private func selectLogDirectory() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.canCreateDirectories = true
-        panel.prompt = L("settings.general.logging.choose_button")
-        panel.begin { response in
-            guard response == .OK, let url = panel.url else {
-                if !config.historyLogWarningShown {
-                    config.historyLogEnabled = false
-                    ConfigStore.shared.update { $0.historyLogEnabled = false }
-                }
-                return
-            }
-            config.historyLogDirectory = url.path
-            config.historyLogEnabled = true
-            config.historyLogWarningShown = true
-            ConfigStore.shared.update {
-                $0.historyLogDirectory = url.path
-                $0.historyLogEnabled = true
-                $0.historyLogWarningShown = true
-            }
-            Task { await HistoryLogger.shared.resetHandleCache() }
-        }
-    }
-
-    private func relaunchApp() {
-        let path = Bundle.main.bundleURL.path
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        task.arguments = ["-n", path]
-        try? task.run()
-        NSApp.terminate(nil)
-    }
-
-    private func saveHotkey() {
-        ConfigStore.shared.update {
-            $0.hotkeyKeyCode = config.hotkeyKeyCode
-            $0.hotkeyModifiers = config.hotkeyModifiers
-        }
-        NotificationCenter.default.post(name: .hotkeyDidChange, object: nil)
-    }
+    // MARK: - Actions Tab
 
     private var actionsTab: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -460,69 +432,11 @@ struct SettingsView: View {
         }
     }
 
-    private func exportActions() {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        guard let data = try? encoder.encode(config.actions) else { return }
-        let panel = NSSavePanel()
-        panel.title = "Exportovat akce"
-        panel.nameFieldStringValue = "JZLLMContext-actions.json"
-        panel.allowedContentTypes = [.json]
-        panel.begin { response in
-            guard response == .OK, let url = panel.url else { return }
-            try? data.write(to: url, options: .atomic)
-        }
-    }
-
-    private func importActions() {
-        let panel = NSOpenPanel()
-        panel.title = "Importovat akce"
-        panel.allowedContentTypes = [.json]
-        panel.allowsMultipleSelection = false
-        panel.begin { response in
-            guard response == .OK, let url = panel.url,
-                  let data = try? Data(contentsOf: url),
-                  let actions = try? JSONDecoder().decode([Action].self, from: data),
-                  !actions.isEmpty else { return }
-            DispatchQueue.main.async {
-                importedActions = actions
-                showImportAlert = true
-            }
-        }
-    }
-
-    private func exportConfig() {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        guard let data = try? encoder.encode(ConfigStore.shared.config) else { return }
-        let panel = NSSavePanel()
-        panel.title = "Exportovat konfiguraci"
-        panel.nameFieldStringValue = "JZLLMContext-config.json"
-        panel.allowedContentTypes = [.json]
-        panel.begin { response in
-            guard response == .OK, let url = panel.url else { return }
-            try? data.write(to: url, options: .atomic)
-        }
-    }
-
-    private func importConfig() {
-        let panel = NSOpenPanel()
-        panel.title = "Importovat konfiguraci"
-        panel.allowedContentTypes = [.json]
-        panel.allowsMultipleSelection = false
-        panel.begin { response in
-            guard response == .OK, let url = panel.url,
-                  let data = try? Data(contentsOf: url),
-                  let cfg = try? JSONDecoder().decode(AppConfig.self, from: data) else { return }
-            DispatchQueue.main.async {
-                importedConfig = cfg
-                showConfigImportAlert = true
-            }
-        }
-    }
+    // MARK: - Providers Tab
 
     private var providersTab: some View {
         Form {
+            // Built-in providers
             Section("OpenAI") {
                 LabeledContent(L("settings.providers.api_key")) {
                     SecureField("", text: $openaiKey)
@@ -632,76 +546,25 @@ struct SettingsView: View {
                 saveButton(for: .azureOpenai2, key: azureKey2)
                 testConnectionRow(for: .azureOpenai2)
             }
-            Section(L("provider.custom1")) {
-                LabeledContent(L("settings.providers.custom.base_url")) {
-                    TextField("", text: Binding(
-                        get: { config.customOpenAIBaseURL ?? "" },
-                        set: {
-                            config.customOpenAIBaseURL = $0.isEmpty ? nil : $0
-                            ConfigStore.shared.update { $0.customOpenAIBaseURL = config.customOpenAIBaseURL }
-                        }
-                    ))
-                }
-                LabeledContent(L("settings.providers.custom.api_version")) {
-                    TextField("", text: Binding(
-                        get: { config.customOpenAIAPIVersion ?? "" },
-                        set: {
-                            config.customOpenAIAPIVersion = $0.isEmpty ? nil : $0
-                            ConfigStore.shared.update { $0.customOpenAIAPIVersion = config.customOpenAIAPIVersion }
-                        }
-                    ))
-                }
-                Picker(L("settings.providers.token_param"), selection: $config.customOpenAITokenParam) {
-                    ForEach(TokenParamStyle.allCases, id: \.self) { style in
-                        Text(style.displayName).tag(style)
-                    }
-                }
-                .onChange(of: config.customOpenAITokenParam) { _, val in
-                    ConfigStore.shared.update { $0.customOpenAITokenParam = val }
-                }
-                LabeledContent(L("settings.providers.api_key_optional")) {
-                    SecureField("", text: $customKey)
-                        .onSubmit { saveKey(customKey, for: .customOpenAI) }
-                }
-                saveButton(for: .customOpenAI, key: customKey)
-                testConnectionRow(for: .customOpenAI)
-                fetchModelsRow(for: .customOpenAI)
+
+            // Dynamic custom providers
+            ForEach($config.customProviders) { $cp in
+                customProviderSection(cp: $cp)
             }
-            Section(L("provider.custom2")) {
-                LabeledContent(L("settings.providers.custom.base_url")) {
-                    TextField("", text: Binding(
-                        get: { config.customOpenAIBaseURL2 ?? "" },
-                        set: {
-                            config.customOpenAIBaseURL2 = $0.isEmpty ? nil : $0
-                            ConfigStore.shared.update { $0.customOpenAIBaseURL2 = config.customOpenAIBaseURL2 }
-                        }
-                    ))
+
+            Section {
+                Button {
+                    let newCP = CustomProvider(name: L("settings.providers.custom.new_name"),
+                                               baseURL: "")
+                    config.customProviders.append(newCP)
+                    ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                } label: {
+                    Label(L("settings.providers.add_custom"), systemImage: "plus")
                 }
-                LabeledContent(L("settings.providers.custom.api_version")) {
-                    TextField("", text: Binding(
-                        get: { config.customOpenAIAPIVersion2 ?? "" },
-                        set: {
-                            config.customOpenAIAPIVersion2 = $0.isEmpty ? nil : $0
-                            ConfigStore.shared.update { $0.customOpenAIAPIVersion2 = config.customOpenAIAPIVersion2 }
-                        }
-                    ))
-                }
-                Picker(L("settings.providers.token_param"), selection: $config.customOpenAITokenParam2) {
-                    ForEach(TokenParamStyle.allCases, id: \.self) { style in
-                        Text(style.displayName).tag(style)
-                    }
-                }
-                .onChange(of: config.customOpenAITokenParam2) { _, val in
-                    ConfigStore.shared.update { $0.customOpenAITokenParam2 = val }
-                }
-                LabeledContent(L("settings.providers.api_key_optional")) {
-                    SecureField("", text: $customKey2)
-                        .onSubmit { saveKey(customKey2, for: .customOpenAI2) }
-                }
-                saveButton(for: .customOpenAI2, key: customKey2)
-                testConnectionRow(for: .customOpenAI2)
-                fetchModelsRow(for: .customOpenAI2)
             }
+
+            // Model filters
+            modelFiltersSection
         }
         .formStyle(.grouped)
         .padding()
@@ -716,6 +579,236 @@ struct SettingsView: View {
             }
         }
     }
+
+    // MARK: - Custom Provider Section
+
+    @ViewBuilder
+    private func customProviderSection(cp: Binding<CustomProvider>) -> some View {
+        let cpID = cp.wrappedValue.id
+        let provider = ProviderType(cpID.uuidString)
+        let keyBinding = Binding<String>(
+            get: { customProviderKeys[cpID.uuidString] ?? "" },
+            set: { customProviderKeys[cpID.uuidString] = $0 }
+        )
+
+        Section {
+            LabeledContent(L("settings.providers.custom.name")) {
+                TextField("", text: cp.name)
+                    .onChange(of: cp.wrappedValue.name) { _, _ in
+                        ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                    }
+            }
+            LabeledContent(L("settings.providers.custom.base_url")) {
+                TextField("https://…", text: cp.baseURL)
+                    .onChange(of: cp.wrappedValue.baseURL) { _, _ in
+                        ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                    }
+            }
+            LabeledContent(L("settings.providers.custom.api_version")) {
+                TextField("", text: Binding(
+                    get: { cp.wrappedValue.apiVersion ?? "" },
+                    set: { cp.apiVersion.wrappedValue = $0.isEmpty ? nil : $0 }
+                ))
+                .onChange(of: cp.wrappedValue.apiVersion) { _, _ in
+                    ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                }
+            }
+            Picker(L("settings.providers.token_param"), selection: cp.tokenParamStyle) {
+                ForEach(TokenParamStyle.allCases, id: \.self) { style in
+                    Text(style.displayName).tag(style)
+                }
+            }
+            .onChange(of: cp.wrappedValue.tokenParamStyle) { _, _ in
+                ConfigStore.shared.update { $0.customProviders = config.customProviders }
+            }
+            Toggle(L("settings.providers.custom.requires_key"), isOn: cp.requiresAPIKey)
+                .onChange(of: cp.wrappedValue.requiresAPIKey) { _, _ in
+                    ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                }
+            LabeledContent(L("settings.providers.api_key_optional")) {
+                SecureField("", text: keyBinding)
+                    .onSubmit { saveKey(keyBinding.wrappedValue, for: provider) }
+            }
+            saveButton(for: provider, key: keyBinding.wrappedValue)
+
+            // Custom headers
+            customHeadersRows(cp: cp, cpID: cpID)
+
+            testConnectionRow(for: provider)
+            fetchModelsRow(for: provider)
+
+            Button(role: .destructive) {
+                providerToDelete = cp.wrappedValue
+                showDeleteProviderAlert = true
+            } label: {
+                Label(L("settings.providers.custom.delete"), systemImage: "trash")
+                    .foregroundStyle(.red)
+            }
+        } header: {
+            Text(cp.wrappedValue.name.isEmpty ? L("settings.providers.custom.unnamed") : cp.wrappedValue.name)
+        }
+    }
+
+    @ViewBuilder
+    private func customHeadersRows(cp: Binding<CustomProvider>, cpID: UUID) -> some View {
+        DisclosureGroup(L("settings.providers.custom.headers")) {
+            ForEach(Array(cp.wrappedValue.customHeaders.keys.sorted()), id: \.self) { key in
+                HStack {
+                    Text(key)
+                        .frame(width: 130, alignment: .leading)
+                        .foregroundStyle(.secondary)
+                    Text(cp.wrappedValue.customHeaders[key] ?? "")
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Spacer()
+                    Button(role: .destructive) {
+                        var headers = cp.wrappedValue.customHeaders
+                        headers.removeValue(forKey: key)
+                        cp.customHeaders.wrappedValue = headers
+                        ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                    } label: {
+                        Image(systemName: "minus.circle").foregroundStyle(.red)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .font(.caption)
+            }
+            HStack(spacing: 6) {
+                TextField(L("settings.providers.custom.header_key"), text: Binding(
+                    get: { newHeaderKey[cpID] ?? "" },
+                    set: { newHeaderKey[cpID] = $0 }
+                ))
+                .frame(width: 130)
+                TextField(L("settings.providers.custom.header_value"), text: Binding(
+                    get: { newHeaderValue[cpID] ?? "" },
+                    set: { newHeaderValue[cpID] = $0 }
+                ))
+                Button(L("common.add")) {
+                    guard let k = newHeaderKey[cpID], !k.isEmpty,
+                          let v = newHeaderValue[cpID], !v.isEmpty else { return }
+                    var headers = cp.wrappedValue.customHeaders
+                    headers[k] = v
+                    cp.customHeaders.wrappedValue = headers
+                    ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                    newHeaderKey[cpID] = ""
+                    newHeaderValue[cpID] = ""
+                }
+                .disabled((newHeaderKey[cpID] ?? "").isEmpty || (newHeaderValue[cpID] ?? "").isEmpty)
+            }
+            .font(.caption)
+        }
+    }
+
+    private func performDeleteCustomProvider(_ cp: CustomProvider) {
+        let providerType = ProviderType(cp.id.uuidString)
+        KeychainStore.delete(for: providerType)
+        // Reset any actions using this provider back to openai
+        ConfigStore.shared.update {
+            $0.customProviders.removeAll { $0.id == cp.id }
+            for i in $0.actions.indices where $0.actions[i].provider == providerType {
+                $0.actions[i].provider = .openai
+                $0.actions[i].model = "gpt-5.5"
+            }
+            $0.modelPresets.removeValue(forKey: cp.id.uuidString)
+        }
+        config = ConfigStore.shared.config
+        customProviderKeys.removeValue(forKey: cp.id.uuidString)
+        providerToDelete = nil
+    }
+
+    // MARK: - Model Filters Section
+
+    private var modelFiltersSection: some View {
+        Section(L("settings.providers.model_filters")) {
+            // Exclude
+            LabeledContent {
+                filterTagsRow(
+                    filters: $config.modelExcludeFilters,
+                    onRemove: { idx in
+                        config.modelExcludeFilters.remove(at: idx)
+                        ConfigStore.shared.update { $0.modelExcludeFilters = config.modelExcludeFilters }
+                    }
+                )
+            } label: {
+                Text(L("settings.providers.model_exclude_filter"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            HStack(spacing: 6) {
+                TextField(L("settings.providers.model_filter.placeholder"), text: $newExcludeFilter)
+                    .onSubmit { addExcludeFilter() }
+                Button(L("common.add")) { addExcludeFilter() }
+                    .disabled(newExcludeFilter.isEmpty)
+            }
+            Text(L("settings.providers.model_filter.hint_exclude"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            // Include
+            LabeledContent {
+                filterTagsRow(
+                    filters: $config.modelIncludeFilters,
+                    onRemove: { idx in
+                        config.modelIncludeFilters.remove(at: idx)
+                        ConfigStore.shared.update { $0.modelIncludeFilters = config.modelIncludeFilters }
+                    }
+                )
+            } label: {
+                Text(L("settings.providers.model_include_filter"))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            HStack(spacing: 6) {
+                TextField(L("settings.providers.model_filter.placeholder"), text: $newIncludeFilter)
+                    .onSubmit { addIncludeFilter() }
+                Button(L("common.add")) { addIncludeFilter() }
+                    .disabled(newIncludeFilter.isEmpty)
+            }
+            Text(L("settings.providers.model_filter.hint_include"))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private func filterTagsRow(filters: Binding<[String]>, onRemove: @escaping (Int) -> Void) -> some View {
+        if filters.wrappedValue.isEmpty {
+            Text("—").foregroundStyle(.secondary).font(.caption)
+        } else {
+            HStack(spacing: 4) {
+                ForEach(Array(filters.wrappedValue.enumerated()), id: \.offset) { idx, filter in
+                    HStack(spacing: 3) {
+                        Text(filter).font(.caption)
+                        Button { onRemove(idx) } label: {
+                            Image(systemName: "xmark").font(.system(size: 9))
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .padding(.horizontal, 6).padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.15))
+                    .cornerRadius(4)
+                }
+            }
+        }
+    }
+
+    private func addExcludeFilter() {
+        let s = newExcludeFilter.trimmingCharacters(in: .whitespaces)
+        guard !s.isEmpty, !config.modelExcludeFilters.contains(s) else { return }
+        config.modelExcludeFilters.append(s)
+        ConfigStore.shared.update { $0.modelExcludeFilters = config.modelExcludeFilters }
+        newExcludeFilter = ""
+    }
+
+    private func addIncludeFilter() {
+        let s = newIncludeFilter.trimmingCharacters(in: .whitespaces)
+        guard !s.isEmpty, !config.modelIncludeFilters.contains(s) else { return }
+        config.modelIncludeFilters.append(s)
+        ConfigStore.shared.update { $0.modelIncludeFilters = config.modelIncludeFilters }
+        newIncludeFilter = ""
+    }
+
+    // MARK: - Shared Provider Helpers
 
     @ViewBuilder
     private func fetchModelsRow(for provider: ProviderType) -> some View {
@@ -829,14 +922,126 @@ struct SettingsView: View {
     }
 
     private func loadKeys() {
-        openaiKey = (try? KeychainStore.load(for: .openai)) ?? ""
+        openaiKey    = (try? KeychainStore.load(for: .openai)) ?? ""
         anthropicKey = (try? KeychainStore.load(for: .anthropic)) ?? ""
-        geminiKey = (try? KeychainStore.load(for: .gemini)) ?? ""
-        grokKey = (try? KeychainStore.load(for: .grok)) ?? ""
-        azureKey = (try? KeychainStore.load(for: .azureOpenai)) ?? ""
-        azureKey2 = (try? KeychainStore.load(for: .azureOpenai2)) ?? ""
-        customKey = (try? KeychainStore.load(for: .customOpenAI)) ?? ""
-        customKey2 = (try? KeychainStore.load(for: .customOpenAI2)) ?? ""
+        geminiKey    = (try? KeychainStore.load(for: .gemini)) ?? ""
+        grokKey      = (try? KeychainStore.load(for: .grok)) ?? ""
+        azureKey     = (try? KeychainStore.load(for: .azureOpenai)) ?? ""
+        azureKey2    = (try? KeychainStore.load(for: .azureOpenai2)) ?? ""
+        for cp in config.customProviders {
+            let provider = ProviderType(cp.id.uuidString)
+            customProviderKeys[cp.id.uuidString] = (try? KeychainStore.load(for: provider)) ?? ""
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func isValidRegex(_ pattern: String) -> Bool {
+        !pattern.isEmpty && (try? NSRegularExpression(pattern: pattern)) != nil
+    }
+
+    private func selectLogDirectory() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.canCreateDirectories = true
+        panel.prompt = L("settings.general.logging.choose_button")
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else {
+                if !config.historyLogWarningShown {
+                    config.historyLogEnabled = false
+                    ConfigStore.shared.update { $0.historyLogEnabled = false }
+                }
+                return
+            }
+            config.historyLogDirectory = url.path
+            config.historyLogEnabled = true
+            config.historyLogWarningShown = true
+            ConfigStore.shared.update {
+                $0.historyLogDirectory = url.path
+                $0.historyLogEnabled = true
+                $0.historyLogWarningShown = true
+            }
+            Task { await HistoryLogger.shared.resetHandleCache() }
+        }
+    }
+
+    private func relaunchApp() {
+        let path = Bundle.main.bundleURL.path
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        task.arguments = ["-n", path]
+        try? task.run()
+        NSApp.terminate(nil)
+    }
+
+    private func saveHotkey() {
+        ConfigStore.shared.update {
+            $0.hotkeyKeyCode = config.hotkeyKeyCode
+            $0.hotkeyModifiers = config.hotkeyModifiers
+        }
+        NotificationCenter.default.post(name: .hotkeyDidChange, object: nil)
+    }
+
+    private func exportActions() {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(config.actions) else { return }
+        let panel = NSSavePanel()
+        panel.title = "Exportovat akce"
+        panel.nameFieldStringValue = "JZLLMContext-actions.json"
+        panel.allowedContentTypes = [.json]
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            try? data.write(to: url, options: .atomic)
+        }
+    }
+
+    private func importActions() {
+        let panel = NSOpenPanel()
+        panel.title = "Importovat akce"
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.begin { response in
+            guard response == .OK, let url = panel.url,
+                  let data = try? Data(contentsOf: url),
+                  let actions = try? JSONDecoder().decode([Action].self, from: data),
+                  !actions.isEmpty else { return }
+            DispatchQueue.main.async {
+                importedActions = actions
+                showImportAlert = true
+            }
+        }
+    }
+
+    private func exportConfig() {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(ConfigStore.shared.config) else { return }
+        let panel = NSSavePanel()
+        panel.title = "Exportovat konfiguraci"
+        panel.nameFieldStringValue = "JZLLMContext-config.json"
+        panel.allowedContentTypes = [.json]
+        panel.begin { response in
+            guard response == .OK, let url = panel.url else { return }
+            try? data.write(to: url, options: .atomic)
+        }
+    }
+
+    private func importConfig() {
+        let panel = NSOpenPanel()
+        panel.title = "Importovat konfiguraci"
+        panel.allowedContentTypes = [.json]
+        panel.allowsMultipleSelection = false
+        panel.begin { response in
+            guard response == .OK, let url = panel.url,
+                  let data = try? Data(contentsOf: url),
+                  let cfg = try? JSONDecoder().decode(AppConfig.self, from: data) else { return }
+            DispatchQueue.main.async {
+                importedConfig = cfg
+                showConfigImportAlert = true
+            }
+        }
     }
 }
 
@@ -847,6 +1052,22 @@ private struct ModelReviewSheet: View {
     @Binding var models: [FetchedModel]
     let onSave: ([FetchedModel]) -> Void
     let onCancel: () -> Void
+
+    private var visibleModels: [FetchedModel] {
+        let cfg = ConfigStore.shared.config
+        var result = models
+        if !cfg.modelIncludeFilters.isEmpty {
+            result = result.filter { m in
+                cfg.modelIncludeFilters.contains { m.id.lowercased().contains($0.lowercased()) }
+            }
+        }
+        if !cfg.modelExcludeFilters.isEmpty {
+            result = result.filter { m in
+                !cfg.modelExcludeFilters.contains { m.id.lowercased().contains($0.lowercased()) }
+            }
+        }
+        return result
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -859,37 +1080,40 @@ private struct ModelReviewSheet: View {
             Divider()
 
             List($models) { $model in
-                HStack(spacing: 10) {
-                    Toggle("", isOn: $model.isIncluded)
-                        .labelsHidden()
-                        .onChange(of: model.isIncluded) { _, included in
-                            if !included && model.isRecommended {
-                                model.isRecommended = false
+                let isVisible = visibleModels.contains(where: { $0.id == model.id })
+                if isVisible {
+                    HStack(spacing: 10) {
+                        Toggle("", isOn: $model.isIncluded)
+                            .labelsHidden()
+                            .onChange(of: model.isIncluded) { _, included in
+                                if !included && model.isRecommended {
+                                    model.isRecommended = false
+                                }
+                            }
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(model.displayName)
+                                .strikethrough(!model.isIncluded, color: .secondary)
+                                .foregroundStyle(model.isIncluded ? .primary : .secondary)
+                            if model.inUseByAction {
+                                Text(L("settings.models.in_use"))
+                                    .font(.caption2)
+                                    .foregroundStyle(.orange)
                             }
                         }
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(model.displayName)
-                            .strikethrough(!model.isIncluded, color: .secondary)
-                            .foregroundStyle(model.isIncluded ? .primary : .secondary)
-                        if model.inUseByAction {
-                            Text(L("settings.models.in_use"))
-                                .font(.caption2)
-                                .foregroundStyle(.orange)
+                        Spacer()
+                        Button {
+                            let targetID = model.id
+                            for i in models.indices {
+                                models[i].isRecommended = models[i].id == targetID
+                            }
+                        } label: {
+                            Image(systemName: model.isRecommended ? "star.fill" : "star")
+                                .foregroundStyle(model.isRecommended ? Color.yellow : Color.secondary)
                         }
+                        .buttonStyle(.plain)
+                        .disabled(!model.isIncluded)
+                        .help(L("settings.models.help.recommend"))
                     }
-                    Spacer()
-                    Button {
-                        let targetID = model.id
-                        for i in models.indices {
-                            models[i].isRecommended = models[i].id == targetID
-                        }
-                    } label: {
-                        Image(systemName: model.isRecommended ? "star.fill" : "star")
-                            .foregroundStyle(model.isRecommended ? Color.yellow : Color.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(!model.isIncluded)
-                    .help(L("settings.models.help.recommend"))
                 }
             }
 
@@ -923,7 +1147,7 @@ private struct ActionRow: View {
 
     private let customSentinel = "__custom__"
 
-    private var isCustom: Bool { pickerModel == customSentinel }
+    private var isCustomModel: Bool { pickerModel == customSentinel }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -1036,7 +1260,7 @@ private struct ActionRow: View {
                     }
                 }
 
-                if isCustom {
+                if isCustomModel {
                     TextField(L("action.row.model_placeholder"), text: $customModelText)
                         .frame(width: 160)
                         .onChange(of: customModelText) {
@@ -1085,69 +1309,6 @@ private struct ActionRow: View {
                         .labelsHidden()
                 }
             }
-        }
-    }
-}
-
-// MARK: - ProviderType extensions
-
-extension ProviderType: Identifiable {
-    public var id: String { rawValue }
-}
-
-extension ProviderType {
-    var displayName: String {
-        switch self {
-        case .openai:        L("provider.openai")
-        case .azureOpenai:   L("provider.azure1")
-        case .azureOpenai2:  L("provider.azure2")
-        case .anthropic:     L("provider.anthropic")
-        case .gemini:        L("provider.gemini")
-        case .grok:          L("provider.grok")
-        case .customOpenAI:  L("provider.custom1")
-        case .customOpenAI2: L("provider.custom2")
-        }
-    }
-
-    func effectiveModels() -> [ModelPreset] {
-        let stored = ConfigStore.shared.config.modelPresets[rawValue] ?? []
-        return stored.isEmpty ? presetModels : stored
-    }
-
-    var presetModels: [ModelPreset] {
-        switch self {
-        case .openai:
-            [
-                .init(id: "gpt-5.5",      displayName: "gpt-5.5",             isRecommended: true),
-                .init(id: "gpt-5.4-mini", displayName: "gpt-5.4-mini"),
-                .init(id: "o4-mini",      displayName: "o4-mini (legacy)"),
-                .init(id: "o3",           displayName: "o3 (legacy)"),
-                .init(id: "o3-mini",      displayName: "o3-mini (legacy)"),
-                .init(id: "gpt-4o",       displayName: "gpt-4o (legacy)"),
-                .init(id: "gpt-4o-mini",  displayName: "gpt-4o-mini (legacy)")
-            ]
-        case .azureOpenai, .azureOpenai2:
-            []
-        case .anthropic:
-            [
-                .init(id: "claude-sonnet-4-6",         displayName: "claude-sonnet-4.6", isRecommended: true),
-                .init(id: "claude-opus-4-7",            displayName: "claude-opus-4.7"),
-                .init(id: "claude-haiku-4-5-20251001",  displayName: "claude-haiku-4.5")
-            ]
-        case .gemini:
-            [
-                .init(id: "gemini-3.1-pro",        displayName: "gemini-3.1-pro",        isRecommended: true),
-                .init(id: "gemini-3-flash-preview", displayName: "gemini-3-flash-preview"),
-                .init(id: "gemini-3.1-flash-lite",  displayName: "gemini-3.1-flash-lite")
-            ]
-        case .grok:
-            [
-                .init(id: "grok-4.20",              displayName: "grok-4.20",              isRecommended: true),
-                .init(id: "grok-4.20-non-reasoning", displayName: "grok-4.20-non-reasoning"),
-                .init(id: "grok-4-1-fast-reasoning", displayName: "grok-4.1-fast-reasoning")
-            ]
-        case .customOpenAI, .customOpenAI2:
-            []
         }
     }
 }


### PR DESCRIPTION
## Summary
Replaces the hardcoded two-slot "Custom OpenAI-compatible Provider" system with a dynamic, unlimited list of named custom providers. Users can now add, configure, and delete any number of custom OpenAI-compatible providers, each with independent settings and API keys.

## Key Changes

- **Dynamic Custom Providers**: Replaced `customOpenAIBaseURL`, `customOpenAIBaseURL2`, etc. with a `customProviders: [CustomProvider]` array in `AppConfig`
- **CustomProvider Model**: New `CustomProvider` struct with fields for name, baseURL, apiVersion, tokenParamStyle, requiresAPIKey, and customHeaders
- **ProviderType Enhancement**: Converted `ProviderType` from a simple enum to a `RawRepresentable` struct that can represent both built-in providers and dynamic custom providers by UUID
- **Settings UI Refactoring**: 
  - Replaced two static custom provider sections with a dynamic `ForEach` loop
  - Added "Add custom provider" button to create new providers
  - Added delete functionality with confirmation alert
  - Implemented custom HTTP headers support with add/remove UI
- **Model Filters**: Added global `modelExcludeFilters` and `modelIncludeFilters` arrays to filter models across all providers
- **Provider Factory & Testers**: Updated `ProviderFactory`, `ConnectionTester`, and `ModelFetcher` to handle dynamic custom providers using `provider.isCustom` and `provider.customProvider` properties
- **Keychain Management**: Custom provider API keys are stored using the provider's UUID as the account identifier
- **Migration Support**: Added legacy decoding support for old schema to migrate fixed slots to dynamic providers
- **Localization**: Added new strings for custom provider UI (name, headers, delete confirmation, model filters)

## Implementation Details

- Custom providers are identified by their UUID, allowing them to be referenced in actions and model presets
- When a custom provider is deleted, its API key is removed from Keychain and any actions using it are reset to OpenAI
- Model filters apply globally across all providers in both the action picker and Update Models sheet
- The UI uses `@ViewBuilder` for the custom provider section to support dynamic rendering
- State management for new headers uses UUID-keyed dictionaries to track input fields per provider

https://claude.ai/code/session_01NdHuhgLpeJHqEkVK3MCttE