### PR TITLE
fix: localize language picker System option and fix {{jazyk}} fallback

### DIFF
--- a/Sources/JZLLMContext/Config/AppConfig.swift
+++ b/Sources/JZLLMContext/Config/AppConfig.swift
@@ -34,7 +34,7 @@ enum AppLanguage: String, Codable, CaseIterable {
 
     var displayName: String {
         switch self {
-        case .system: "Systémový"
+        case .system: L("language.option.system")
         case .cs:     "Čeština"
         case .en:     "English"
         case .es:     "Español"

--- a/Sources/JZLLMContext/Resources/Localizable.xcstrings
+++ b/Sources/JZLLMContext/Resources/Localizable.xcstrings
@@ -115,6 +115,14 @@
         "es" : { "stringUnit" : { "state" : "translated", "value" : "desactivado" } }
       }
     },
+    "language.option.system" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Systémový" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "System" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Sistema" } }
+      }
+    },
     "settings.general.section.language" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Sources/JZLLMContext/UI/OverlayView.swift
+++ b/Sources/JZLLMContext/UI/OverlayView.swift
@@ -420,7 +420,7 @@ struct OverlayView: View {
         df.dateStyle = .long
         df.timeStyle = .none
         df.locale = Locale.current
-        let lang = Locale.current.language.languageCode?.identifier ?? "cs"
+        let lang = Locale.current.language.languageCode?.identifier ?? "en"
         return prompt
             .replacingOccurrences(of: "{{datum}}", with: df.string(from: Date()))
             .replacingOccurrences(of: "{{jazyk}}", with: lang)


### PR DESCRIPTION
- AppLanguage.displayName for .system was hardcoded as "Systémový" regardless
  of UI language; now uses L("language.option.system") so EN users see "System"
  and ES users see "Sistema"
- resolveVariables fallback for {{jazyk}} changed from "cs" to "en" to avoid
  telling the LLM to respond in Czech on non-Czech machines when locale detection fails
- Added "language.option.system" key to Localizable.xcstrings (cs/en/es)

https://claude.ai/code/session_0159eo9bpCKKGsVdvQ8Ag9of