### PR TITLE
UX revize tabů Nastavení: sbalovací poskytovatelé, master–detail akce, výška panelu (issue #22, body 4–7, 11, 16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ All code compiles with `SWIFT_STRICT_CONCURRENCY: complete`. Every change must s
 
 Use `UICornerRadius.small` (4) / `.large` (8) for corner radii instead of magic numbers — keeps overlay/settings rounding consistent.
 
+`OverlayWindowController` manages panel height only until the user resizes the panel by hand: `windowDidEndLiveResize` (fires for drag-resize only, never for programmatic `setFrame`) sets `userResizedPanel`, which disables both `adjustPanelHeight()` on open and the animated `expandForResult()` (triggered from `OverlayView` via the `onResultAppeared` callback). Don't add `setFrame` calls that bypass this flag.
+
 `OverlayWindowController` hides the standard traffic-light window buttons (`standardWindowButton(.closeButton/.miniaturizeButton/.zoomButton)?.isHidden = true`); `OverlayView` provides its own ✕ in the header, so don't re-enable the system buttons.
 
 The context `TextField` (`userContextFocused`) must keep keyboard focus so `.onKeyPress(.return, ...)` triggers the default action — `.defaultFocus($userContextFocused, true)` plus explicit `userContextFocused = true` in both `.onAppear` and `.onChange(of: state.refreshID)` (the panel is created once and reused, so `.onAppear` only fires on the very first show). Icon-only header buttons use `iconButton()` (`.buttonStyle(.plain).focusEffectDisabled()`) so they don't steal this focus or break digit shortcuts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,18 @@ All code compiles with `SWIFT_STRICT_CONCURRENCY: complete`. Every change must s
 
 `OpenAIProvider` omits the `temperature` parameter for o-series reasoning models (model id matching `^o\d`) — they reject non-default values with HTTP 400. Azure error paths take the concrete `ProviderType` (slot 1 vs slot 2) so messages point at the right slot.
 
+## Localization
+
+Czech (`cs`) strings in `Localizable.xcstrings` use „poskytovatel/poskytovatelé", never the anglicism „provider" — applies to all new cs strings (en keeps "Provider", es "Proveedor"). Code identifiers (`ProviderType`, `customProviders`, the `provider` JSON key) stay English.
+
+## UI conventions (settings)
+
+The Actions tab is master–detail: `actionList` (selection by action id) + `ActionDetailEditor`, which is recreated per selection via `.id(selectedActionID)`. Its model-picker `@State` must be seeded in `init` with `State(initialValue:)` — `onAppear` does not fire reliably on `.id` identity swaps and left the picker blank.
+
+Provider sections in the Providers tab are collapsible `DisclosureGroup`s (`providerSection` helper; expansion keyed by `provider.rawValue` in `expandedProviders`). Rows inside a `DisclosureGroup` do not fill the row width — button/text rows there need `.frame(maxWidth: .infinity, alignment: .leading)` or they render centered.
+
+Use `FlowLayout` (UIConstants.swift) for wrapping chip/tag rows instead of a plain `HStack` that would overflow.
+
 ## UI conventions (overlay)
 
 Use `UICornerRadius.small` (4) / `.large` (8) for corner radii instead of magic numbers — keeps overlay/settings rounding consistent.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The panel is a floating window displayed above all other apps, visible on all Sp
 - **File drag & drop** – drag any file directly onto the panel; the app extracts the text content locally and uses it as context instead of the clipboard. Supported formats: PDF, images (OCR), DOCX, XLSX, RTF, HTML, PPTX, Pages, Numbers, Keynote, and all plain-text formats (TXT, MD, CSV, JSON, source code, …). Maximum file size: 5 MB. The filename appears in the preview with a × clear button; pressing **Escape** while a file is loaded clears it first (second press closes the panel). File context bypasses the *clipboard ignore* toggle.
 - **Clipboard ignore** – the eye button next to the preview toggles clipboard-free mode; actions receive only the additional context as input; action buttons stay disabled until the additional context field contains text
 - **Clipboard change indicator** – if the clipboard content changes while the panel is open, an accent-colored refresh icon appears below the eye button; clicking it reloads the clipboard content
-- **Result area** – shown after an action completes; text can be selected with the mouse
+- **Result area** – shown after an action completes; text can be selected with the mouse. The panel grows automatically when a result appears; once you resize the panel by hand, your size is kept and automatic height management stops
 - **Post-completion buttons**: **Copy**, **Close**, and **Retry** on error
 - **History** – the clock button in the header shows recent results from the current session; when interaction logging is enabled, an **Open log folder** button appears at the bottom of the history panel
 
@@ -129,19 +129,16 @@ Click the shortcut field, press the desired key combination (must include at lea
 
 ![Settings – Actions](docs/en/screenshot-settings-actions.png)
 
-Manage the actions shown in the overlay panel.
+Manage the actions shown in the overlay panel. The tab uses a master–detail layout: a compact list of actions on the left (enable toggle, name, provider · model, ↩ default marker), and a full editor for the selected action on the right.
 
-- **Add action** – "Add Action" button
-- **Enable/disable** – toggle to the left of the name; disabled actions do not appear in the overlay
-- **Default action** – the ↩ button marks the action triggered by pressing Enter in the context field; only one action can be marked at a time
-- **System prompt** – instructions for the LLM; clipboard content is sent as the user message
+- **Add action** – "Add Action" button; the new action is selected automatically
+- **Enable/disable** – toggle in the list; disabled actions do not appear in the overlay
+- **Default action** – toggle in the editor marks the action triggered by pressing Enter in the context field; only one action can be marked at a time (↩ in the list)
+- **System prompt** – instructions for the LLM with a large editor field; clipboard content is sent as the user message
 - **Provider and model** – select provider and model (see [Custom Models](#custom-models))
-- **Temperature** – slider 0.0–2.0; default 0.7
-- **Ignore clipboard** – when checked, the action always runs without clipboard content; only the additional context field is sent as input (equivalent to toggling the eye button manually)
-- **Copy & Close** – per-action override of the global setting: *Use global setting* / *Always* / *Never*
-- **Max. tokens** – maximum response length
-- **Reordering** – drag & drop to change the order
-- **Delete** – trash button with a confirmation dialog
+- **Parameters** – temperature (slider 0.0–2.0; default 0.7), max. tokens (maximum response length), Copy & Close (per-action override of the global setting: *Use global setting* / *Always* / *Never*), and Ignore clipboard (the action always runs without clipboard content; only the additional context field is sent as input)
+- **Reordering** – drag & drop in the list to change the order
+- **Delete** – button at the bottom of the editor with a confirmation dialog
 - **Import/export actions** – share or back up actions as JSON
 
 All changes are saved immediately.
@@ -517,7 +514,7 @@ This software is provided **"as is"**, without warranty of any kind – express 
 
 Utilita pro macOS menu bar, která zpracovává obsah schránky pomocí různých jazykových modelů. Je určena pro každého, kdo při práci pravidelně používá LLM – překladatele, vývojáře, copywritery i běžné uživatele – a chce mít přístup k AI přímo z klávesnice bez přepínání aplikací.
 
-Zkopíruješ text nebo obrázek, stiskneš globální zkratku a vybraná akce pošle obsah do LLM a vrátí výsledek. Každá akce má vlastní systémový prompt, provider a model. Funguje s OpenAI, Anthropic, Google Gemini, xAI Grok, Azure AI i lokálními modely (Ollama, LM Studio). Všechny akce jsou uživatelsky konfigurovatelné.
+Zkopíruješ text nebo obrázek, stiskneš globální zkratku a vybraná akce pošle obsah do LLM a vrátí výsledek. Každá akce má vlastní systémový prompt, poskytovatele a model. Funguje s OpenAI, Anthropic, Google Gemini, xAI Grok, Azure AI i lokálními modely (Ollama, LM Studio). Všechny akce jsou uživatelsky konfigurovatelné.
 
 ![JZLLMContext – overlay panel](docs/cs/screenshot.png)
 
@@ -532,9 +529,9 @@ Zkopíruješ text nebo obrázek, stiskneš globální zkratku a vybraná akce po
   - [Overlay panel](#overlay-panel-1)
   - [Nastavení – Obecné](#nastavení--obecné)
   - [Nastavení – Akce](#nastavení--akce)
-  - [Nastavení – Providery](#nastavení--providery)
+  - [Nastavení – Poskytovatelé](#nastavení--poskytovatelé)
 - [Vlastní modely](#vlastní-modely)
-- [Vlastní OpenAI-compatible providery](#vlastní-openai-compatible-providery)
+- [Vlastní OpenAI-compatible poskytovatelé](#vlastní-openai-compatible-poskytovatelé)
 - [Odinstalace](#odinstalace)
 - [Technický popis](#technický-popis)
   - [Zpracování souborů](#zpracování-souborů)
@@ -601,7 +598,7 @@ Panel je plovoucí okno zobrazené nad ostatními aplikacemi, viditelné na vše
 - **Doplňkový kontext** – volitelné textové pole pro přidání instrukce nad rámec schránky; stiskem **Enter** se spustí výchozí akce; ikona × pro rychlé vymazání
 - **Tlačítka akcí** – jen povolené akce
   - Spinner = akce právě běží
-  - ⚠ = chybí API klíč pro daný provider
+  - ⚠ = chybí API klíč pro daného poskytovatele
   - Číslo = klávesová zkratka; stisknutí `1`–`9` spustí příslušnou akci bez myši
   - ↩ = výchozí akce (spustí se stiskem Enter v poli kontextu)
   - **Zrušit** – zobrazí se při běžící akci; zastaví požadavek
@@ -609,7 +606,7 @@ Panel je plovoucí okno zobrazené nad ostatními aplikacemi, viditelné na vše
 - **Přetažení souboru (drag & drop)** – přetáhni libovolný soubor přímo na panel; text se extrahuje lokálně a použije jako kontext místo schránky. Podporované formáty: PDF, obrázky (OCR), DOCX, XLSX, RTF, HTML, PPTX, Pages, Numbers, Keynote a všechny plain-text formáty (TXT, MD, CSV, JSON, zdrojový kód, …). Maximální velikost: 5 MB. Název souboru se zobrazí v náhledu s tlačítkem × pro odebrání; stisknutím **Escape** při načteném souboru se soubor nejprve vymaže (druhé stisknutí panel zavře). Kontext ze souboru obchází přepínač *ignorovat schránku*.
 - **Ignorování schránky** – tlačítko oka vedle náhledu přepne panel do režimu bez schránky; akce dostanou jako vstup jen doplňkový kontext; tlačítka akcí zůstávají neaktivní, dokud pole doplňkového kontextu neobsahuje text
 - **Indikátor změny schránky** – pokud se obsah schránky změní při otevřeném panelu, pod tlačítkem oka se zobrazí ikona obnovení v barvě zvýraznění; kliknutím se znovu načte obsah schránky
-- **Oblast výsledku** – zobrazí se po dokončení akce; text lze vybrat myší
+- **Oblast výsledku** – zobrazí se po dokončení akce; text lze vybrat myší. Panel se při zobrazení výsledku automaticky zvětší; jakmile velikost panelu jednou změníte ručně, zachovává se vaše velikost a automatika se vypne
 - **Tlačítka po dokončení**: **Zkopírovat**, **Zavřít**, při chybě **Zkusit znovu**
 - **Historie** – tlačítko hodin v záhlaví; zobrazí poslední výsledky ze session; pokud je zapnuto logování interakcí, zobrazí se na konci panelu tlačítko **Otevřít složku logů**
 
@@ -638,59 +635,58 @@ Klikni na pole se zkratkou, stiskni požadovanou kombinaci (musí obsahovat ales
 
 ![Nastavení – Akce](docs/cs/screenshot-settings-actions.png)
 
-Správa akcí zobrazovaných v overlay panelu.
+Správa akcí zobrazovaných v overlay panelu. Záložka používá rozložení seznam–detail: vlevo kompaktní seznam akcí (přepínač povolení, název, poskytovatel · model, značka ↩ výchozí akce), vpravo plnohodnotný editor vybrané akce.
 
-- **Přidání akce** – tlačítko „Přidat akci"
-- **Zapnutí/vypnutí** – přepínač vlevo od názvu; vypnuté akce se v overlay nezobrazí
-- **Výchozí akce** – tlačítko ↩ označí akci spouštěnou stiskem Enter v poli kontextu; označit lze vždy jen jednu
-- **Systémový prompt** – instrukce pro LLM; obsah schránky se posílá jako uživatelská zpráva
-- **Provider a model** – výběr providera a modelu (viz [Vlastní modely](#vlastní-modely))
-- **Teplota** – slider 0.0–2.0; výchozí 0.7
-- **Ignorovat schránku** – je-li zaškrtnuto, akce se vždy spustí bez obsahu schránky; jako vstup se odešle jen pole doplňkového kontextu (odpovídá ručnímu stisknutí tlačítka oka)
-- **Zkopírovat a zavřít** – per-akce přepis globálního nastavení: *Dle globálního nastavení* / *Vždy* / *Nikdy*
-- **Max. tokenů** – maximální délka odpovědi
-- **Přesouvání** – drag & drop pro změnu pořadí
-- **Mazání** – tlačítko koše s potvrzovacím dialogem
+- **Přidání akce** – tlačítko „Přidat akci"; nová akce se rovnou vybere
+- **Zapnutí/vypnutí** – přepínač v seznamu; vypnuté akce se v overlay nezobrazí
+- **Výchozí akce** – přepínač v editoru označí akci spouštěnou stiskem Enter v poli kontextu; označit lze vždy jen jednu (↩ v seznamu)
+- **Systémový prompt** – instrukce pro LLM s velkým editačním polem; obsah schránky se posílá jako uživatelská zpráva
+- **Poskytovatel a model** – výběr poskytovatele a modelu (viz [Vlastní modely](#vlastní-modely))
+- **Parametry** – teplota (slider 0.0–2.0; výchozí 0.7), max. tokenů (maximální délka odpovědi), Zkopírovat a zavřít (per-akce přepis globálního nastavení: *Dle globálního nastavení* / *Vždy* / *Nikdy*) a Ignorovat schránku (akce se vždy spustí bez obsahu schránky; jako vstup se odešle jen pole doplňkového kontextu)
+- **Přesouvání** – drag & drop v seznamu pro změnu pořadí
+- **Mazání** – tlačítko ve spodní části editoru s potvrzovacím dialogem
 - **Import/export akcí** – sdílení nebo záloha jako JSON
 
 Všechny změny se ukládají okamžitě.
 
-#### Nastavení – Providery
+#### Nastavení – Poskytovatelé
 
-![Nastavení – Providery](docs/cs/screenshot-settings-providers.png)
+![Nastavení – Poskytovatelé](docs/cs/screenshot-settings-providers.png)
+
+Každý poskytovatel je sbalovací sekce — ve výchozím stavu sbalená pro kompaktní přehled. Hlavička sekce ukazuje ikonu klíče (zelená = API klíč uložen) a počet uložených modelů, takže stav konfigurace je vidět bez rozbalení.
 
 **OpenAI, Anthropic, Google Gemini, xAI Grok** – pole pro API klíč, tlačítko Uložit a **Aktualizovat modely** pro načtení aktuálního seznamu přímo z API.
 
 **Azure AI (slot 1 a slot 2)** – každý slot reprezentuje jedno nasazení (deployment) v Azure AI Foundry. Zadej API klíč, Deployment URL a API verzi.
 
-**Vlastní OpenAI-compatible providery** – libovolný počet vlastních providerů kompatibilních s OpenAI Chat Completions API. Přidej provider tlačítkem **+** a nakonfiguruj: název providera (používá se ve výběru akce a v celém UI), Base URL, volitelně API klíč (pro lokální modely lze nechat prázdné), volitelně **API verzi** (přidá parametr `?api-version=…` do URL), **Parametr max. tokenů** (`max_tokens`, `max_completion_tokens`, `max_output_tokens`, `max_new_tokens` – zvol podle toho, co daný server očekává) a volitelné **Vlastní hlavičky** (extra HTTP hlavičky odeslané s každým požadavkem – pro autentizaci, směrování API nebo specifické požadavky serveru). **Aktualizovat modely** načte seznam modelů z endpointu `/models` na daném serveru (funguje s Ollama, LM Studio a většinou OpenAI-compatible serverů); ruční zadání modelu v akci zůstává vždy dostupné. Providery lze odebrat tlačítkem smazat; akce používající smazaný provider se automaticky resetují na OpenAI.
+**Vlastní OpenAI-compatible poskytovatelé** – libovolný počet vlastních poskytovatelů kompatibilních s OpenAI Chat Completions API. Přidej poskytovatele tlačítkem **+** a nakonfiguruj: název poskytovatele (používá se ve výběru akce a v celém UI), Base URL, volitelně API klíč (pro lokální modely lze nechat prázdné), volitelně **API verzi** (přidá parametr `?api-version=…` do URL), **Parametr max. tokenů** (`max_tokens`, `max_completion_tokens`, `max_output_tokens`, `max_new_tokens` – zvol podle toho, co daný server očekává) a volitelné **Vlastní hlavičky** (extra HTTP hlavičky odeslané s každým požadavkem – pro autentizaci, směrování API nebo specifické požadavky serveru). **Aktualizovat modely** načte seznam modelů z endpointu `/models` na daném serveru (funguje s Ollama, LM Studio a většinou OpenAI-compatible serverů); ruční zadání modelu v akci zůstává vždy dostupné. Poskytovatele lze odebrat tlačítkem smazat; akce používající smazaného poskytovatele se automaticky resetují na OpenAI.
 
-**Filtry modelů** – globální filtry platné pro všechny providery. Seznam **Exclude** skryje každý model, jehož ID obsahuje zadaný řetězec (např. přidání `preview` skryje všechny preview modely). Seznam **Include**, je-li neprázdný, zobrazí jen modely, jejichž ID obsahuje alespoň jeden ze zadaných řetězců. Include má přednost před exclude. Filtry se uplatňují ve výběru modelu v akci i v listu Update Models.
+**Filtry modelů** (zobrazené na začátku záložky, protože ovlivňují všechny poskytovatele) – globální filtry platné pro všechny poskytovatele. Seznam **Exclude** skryje každý model, jehož ID obsahuje zadaný řetězec (např. přidání `preview` skryje všechny preview modely). Seznam **Include**, je-li neprázdný, zobrazí jen modely, jejichž ID obsahuje alespoň jeden ze zadaných řetězců. Include má přednost před exclude. Filtry se uplatňují ve výběru modelu v akci i v listu Update Models.
 
-Tlačítko **Ověřit připojení** u každého providera odešle testovací požadavek a zobrazí výsledek.
+Tlačítko **Ověřit připojení** u každého poskytovatele odešle testovací požadavek a zobrazí výsledek.
 
 ---
 
 ### Vlastní modely
 
-Každý provider nabízí předdefinovaný seznam modelů a možnost zadat libovolný model:
+Každý poskytovatel nabízí předdefinovaný seznam modelů a možnost zadat libovolný model:
 
-| Provider | Předdefinované modely |
+| Poskytovatel | Předdefinované modely |
 |----------|----------------------|
 | OpenAI | gpt-5.5, gpt-5.4-mini, o4-mini (legacy), o3 (legacy), o3-mini (legacy), gpt-4o (legacy), gpt-4o-mini (legacy) |
 | Anthropic | claude-sonnet-4.6, claude-opus-4.7, claude-haiku-4.5 |
 | Google Gemini | gemini-3.1-pro, gemini-3-flash-preview, gemini-3.1-flash-lite |
 | xAI Grok | grok-4.20, grok-4.20-non-reasoning, grok-4.1-fast-reasoning |
 | Azure AI (slot 1 / slot 2) | – (model určuje deployment v nastavení) |
-| Vlastní providery | načteno přes Aktualizovat modely (pokud server podporuje `/models`); ruční zadání vždy dostupné |
+| Vlastní poskytovatelé | načteno přes Aktualizovat modely (pokud server podporuje `/models`); ruční zadání vždy dostupné |
 
 Výběr vlastního modelu: v nastavení akce otevři výběr modelu → vyber „Vlastní model…" → zadej přesný identifikátor (např. `gpt-4.5-preview`). Hodnota se uloží okamžitě.
 
 ---
 
-### Vlastní OpenAI-compatible providery
+### Vlastní OpenAI-compatible poskytovatelé
 
-Aplikace podporuje libovolný počet vlastních providerů kompatibilních s OpenAI Chat Completions API. Přidej je v **Nastavení → Providery** tlačítkem **+**. Každý provider má nezávislý název, API klíč a konfiguraci.
+Aplikace podporuje libovolný počet vlastních poskytovatelů kompatibilních s OpenAI Chat Completions API. Přidej je v **Nastavení → Poskytovatelé** tlačítkem **+**. Každý poskytovatel má nezávislý název, API klíč a konfiguraci.
 
 **Ollama (lokální modely)**
 ```
@@ -708,7 +704,7 @@ API klíč: (nechat prázdné nebo libovolný řetězec)
 Model:    (název modelu načteného v LM Studio)
 ```
 
-**Jiný cloud provider (např. Together AI)**
+**Jiný cloudový poskytovatel (např. Together AI)**
 ```
 Název:    Together AI
 Base URL: https://api.together.xyz/v1
@@ -752,7 +748,7 @@ security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.gemin
 security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.grok.apikey"
 security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.azure_openai.apikey"
 security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.azure_openai_2.apikey"
-# Pro každý vlastní provider nahraď <uuid> UUID providera z config.json:
+# Pro každého vlastního poskytovatele nahraď <uuid> UUID poskytovatele z config.json:
 security delete-generic-password -s "com.jz.JZLLMContext" -a "jzllmcontext.<uuid>.apikey"
 ```
 
@@ -767,10 +763,10 @@ Pokud bylo zapnuto „Spustit při přihlášení", odregistruj aplikaci před s
 - **Globální zkratka** – otevře overlay panel s obsahem schránky odkudkoli (výchozí: Cmd+Shift+Space)
 - **Text i obrázky** – čte text ze schránky nebo extrahuje text z obrázků přes Apple Vision OCR
 - **Přetažení souboru** – přetáhnutí souboru přímo na overlay panel; PDF (PDFKit), obrázky (OCR), strukturované dokumenty (DOCX, XLSX, RTF, PPTX, iWork formáty přes Spotlight) a plain-text formáty; maximálně 5 MB; obsah souboru nahradí kontext ze schránky
-- **Více providerů** – OpenAI, Anthropic, Google Gemini, xAI Grok, Azure AI (2 sloty), neomezený počet vlastních OpenAI-compatible providerů (Ollama, LM Studio, OpenRouter, …)
-- **Vlastní akce** – libovolný počet akcí se systémovými prompty; každá má vlastní provider, model, teplotu a limit tokenů
+- **Více poskytovatelů** – OpenAI, Anthropic, Google Gemini, xAI Grok, Azure AI (2 sloty), neomezený počet vlastních OpenAI-compatible poskytovatelů (Ollama, LM Studio, OpenRouter, …)
+- **Vlastní akce** – libovolný počet akcí se systémovými prompty; každá má vlastního poskytovatele, model, teplotu a limit tokenů
 - **Správa akcí** – zapínání/vypínání, drag & drop řazení, mazání s potvrzením, import/export jako JSON
-- **Vlastní modely** – každý provider podporuje zadání libovolného modelu mimo předdefinovaný seznam
+- **Vlastní modely** – každý poskytovatel podporuje zadání libovolného modelu mimo předdefinovaný seznam
 - **Klávesové zkratky** – akce 1–9 lze spustit stiskem příslušné číslice přímo v overlay panelu
 - **Výchozí akce** – jedna akce může být označena jako výchozí; spustí se stiskem Enter v poli doplňkového kontextu
 - **Doplňkový kontext** – volitelné textové pole v overlay pro přidání instrukce nad rámec schránky
@@ -781,9 +777,9 @@ Pokud bylo zapnuto „Spustit při přihlášení", odregistruj aplikaci před s
 - **Spuštění při přihlášení** – volitelná integrace se Service Management
 - **Automatické zkopírování a zavření** – globální přepínač i per-akce přepis (Vždy / Nikdy / Dle globálního nastavení)
 - **Formátování výsledku** – globální přepínač; výsledek lze zobrazit s Markdown formátováním nebo jako prostý text
-- **Aktualizace seznamu modelů online** – tlačítkem v nastavení providerů lze načíst aktuální modely přímo z API; vlastní OpenAI-compatible providery načítají modely z endpointu `/models` na daném serveru
-- **Filtry modelů** – globální seznamy include a exclude filtrů; modely jejichž ID obsahuje exclude řetězec jsou skryty u všech providerů; jsou-li zadány include řetězce, zobrazí se jen shodné modely; filtry se uplatňují ve výběru modelu i v listu Update Models
-- **Vlastní HTTP hlavičky** – každý vlastní provider může posílat libovolné extra HTTP hlavičky s každým požadavkem (pro API routing, autentizaci nebo specifické požadavky jako `HTTP-Referer` na OpenRouter)
+- **Aktualizace seznamu modelů online** – tlačítkem v nastavení poskytovatelů lze načíst aktuální modely přímo z API; vlastní OpenAI-compatible poskytovatelé načítají modely z endpointu `/models` na daném serveru
+- **Filtry modelů** – globální seznamy include a exclude filtrů; modely jejichž ID obsahuje exclude řetězec jsou skryty u všech poskytovatelů; jsou-li zadány include řetězce, zobrazí se jen shodné modely; filtry se uplatňují ve výběru modelu i v listu Update Models
+- **Vlastní HTTP hlavičky** – každý vlastní poskytovatel může posílat libovolné extra HTTP hlavičky s každým požadavkem (pro API routing, autentizaci nebo specifické požadavky jako `HTTP-Referer` na OpenRouter)
 - **Test připojení** – ověří, zda je API klíč a konfigurace funkční
 - **Záloha konfigurace** – export/import celé konfigurace jako JSON; API klíče ani hodnoty vlastních HTTP hlaviček nejsou exportovány
 - **Reset konfigurace** – obnoví výchozí nastavení jedním kliknutím; API klíče v Keychainu zůstanou
@@ -795,7 +791,7 @@ Pokud bylo zapnuto „Spustit při přihlášení", odregistruj aplikaci před s
 #### Požadavky
 
 - macOS 15.0 (Sequoia) nebo novější
-- API klíč alespoň jednoho podporovaného providera
+- API klíč alespoň jednoho podporovaného poskytovatele
 
 #### Instalace a sestavení
 
@@ -873,7 +869,7 @@ Konfigurace (akce, zkratka, Azure/Custom URL) se ukládá do JSON souboru atomic
 
 API klíče jsou uloženy v macOS Keychain pod service `com.jz.JZLLMContext`:
 
-| Provider | Keychain account |
+| Poskytovatel | Keychain account |
 |----------|-----------------|
 | OpenAI | `jzllmcontext.openai.apikey` |
 | Anthropic | `jzllmcontext.anthropic.apikey` |
@@ -881,7 +877,7 @@ API klíče jsou uloženy v macOS Keychain pod service `com.jz.JZLLMContext`:
 | xAI Grok | `jzllmcontext.grok.apikey` |
 | Azure AI slot 1 | `jzllmcontext.azure_openai.apikey` |
 | Azure AI slot 2 | `jzllmcontext.azure_openai_2.apikey` |
-| Vlastní provider | `jzllmcontext.<uuid>.apikey` (UUID přiřazeno při vytvoření providera) |
+| Vlastní poskytovatel | `jzllmcontext.<uuid>.apikey` (UUID přiřazeno při vytvoření poskytovatele) |
 
 #### Struktura konfiguračního souboru
 
@@ -934,11 +930,11 @@ API klíče jsou uloženy v macOS Keychain pod service `com.jz.JZLLMContext`:
 
 Hodnoty `hotkeyKeyCode` a `hotkeyModifiers` jsou kódy Carbon API. Výchozí zkratka Cmd+Shift+Space odpovídá `keyCode: 49`, `modifiers: 768`.
 
-Provider se ukládá jako string: `"openai"`, `"anthropic"`, `"gemini"`, `"grok"`, `"azure_openai"`, `"azure_openai_2"`, nebo UUID string vlastního providera (např. `"a1b2c3d4-e5f6-7890-abcd-ef1234567890"`).
+Poskytovatel se ukládá jako string: `"openai"`, `"anthropic"`, `"gemini"`, `"grok"`, `"azure_openai"`, `"azure_openai_2"`, nebo UUID string vlastního poskytovatele (např. `"a1b2c3d4-e5f6-7890-abcd-ef1234567890"`).
 
-#### Providery a jejich limity
+#### Poskytovatelé a jejich limity
 
-| Provider | Endpoint | Teplota | Poznámka |
+| Poskytovatel | Endpoint | Teplota | Poznámka |
 |----------|----------|---------|----------|
 | OpenAI | `https://api.openai.com/v1/chat/completions` | 0.0–2.0 | Standard Bearer auth |
 | Anthropic | `https://api.anthropic.com/v1/messages` | 0.0–1.0 | Teplota oříznutá na 1.0; header `x-api-key` + `anthropic-version: 2023-06-01` |
@@ -946,7 +942,7 @@ Provider se ukládá jako string: `"openai"`, `"anthropic"`, `"gemini"`, `"grok"
 | xAI Grok | `https://api.x.ai/v1/chat/completions` | 0.0–2.0 | OpenAI-compatible endpoint; Bearer auth |
 | Azure AI (slot 1) | `{endpoint}/chat/completions?api-version=...` | 0.0–2.0 | Header `api-key: {key}`; model v body ignorován – model určuje deployment |
 | Azure AI (slot 2) | totéž jako slot 1, jiná konfigurace | 0.0–2.0 | Nezávislý slot pro druhý deployment |
-| Vlastní provider (libovolný) | `{baseURL}/chat/completions` | 0.0–2.0 | OpenAI Chat Completions protokol; API klíč, API verze i vlastní hlavičky jsou volitelné; funguje s Ollama, LM Studio, OpenRouter, Together AI atd. |
+| Vlastní poskytovatel (libovolný) | `{baseURL}/chat/completions` | 0.0–2.0 | OpenAI Chat Completions protokol; API klíč, API verze i vlastní hlavičky jsou volitelné; funguje s Ollama, LM Studio, OpenRouter, Together AI atd. |
 
 Timeout všech HTTP požadavků: **60 sekund**. Parametr `temperature` se vynechává u o-series reasoning modelů (ID modelu začínající `o1`/`o3`/`o4`), které jinou než výchozí hodnotu odmítají.
 

--- a/README.md
+++ b/README.md
@@ -150,13 +150,15 @@ All changes are saved immediately.
 
 ![Settings – Providers](docs/en/screenshot-settings-providers.png)
 
+Each provider is a collapsible section — collapsed by default for a compact overview. The section header shows a key icon (green when an API key is saved) and the number of saved models, so the configuration state is visible without expanding.
+
 **OpenAI, Anthropic, Google Gemini, xAI Grok** – API key field, Save button, and **Update Models** to fetch the current model list directly from the API.
 
 **Azure AI (slot 1 and slot 2)** – each slot represents one deployment in Azure AI Foundry. Enter the API key, Deployment URL, and API version.
 
 **Custom OpenAI-compatible providers** – any number of custom providers compatible with the OpenAI Chat Completions API. Add a provider with the **+** button and configure: provider name (used in the action picker and all UI), Base URL, optionally an API key (leave empty for local models), optionally an **API version** (appends `?api-version=…` to the URL), the **Max tokens parameter** (`max_tokens`, `max_completion_tokens`, `max_output_tokens`, `max_new_tokens` – select based on what the server expects), and optional **Custom Headers** (extra HTTP headers sent with every request – useful for authentication headers, API routing, or service-specific requirements). **Update Models** fetches the model list from the server's `/models` endpoint (compatible with Ollama, LM Studio, and most OpenAI-compatible servers); manual model entry per action always remains available. Providers can be removed with the delete button; actions using the deleted provider are automatically reset to OpenAI.
 
-**Model Filters** – global filters that apply across all providers. The **Exclude** list hides any model whose ID contains one of the specified strings (e.g. adding `preview` hides all preview models). The **Include** list, when non-empty, shows only models whose ID contains at least one of the specified strings. Include takes priority over exclude. Filters apply in the action model picker and in the Update Models sheet.
+**Model Filters** (shown at the top of the tab, since they affect every provider) – global filters that apply across all providers. The **Exclude** list hides any model whose ID contains one of the specified strings (e.g. adding `preview` hides all preview models). The **Include** list, when non-empty, shows only models whose ID contains at least one of the specified strings. Include takes priority over exclude. Filters apply in the action model picker and in the Update Models sheet.
 
 The **Verify Connection** button for each provider sends a test request and displays the result.
 

--- a/Sources/JZLLMContext/Resources/Localizable.xcstrings
+++ b/Sources/JZLLMContext/Resources/Localizable.xcstrings
@@ -75,7 +75,7 @@
     "settings.tab.providers" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Providery" } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Poskytovatelé" } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Providers" } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Proveedores" } }
       }
@@ -432,7 +432,7 @@
     "settings.alert.reset.message" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Tato akce odstraní všechny akce, globální zkratku, nastavení providerů a ostatní volby. API klíče v Keychainu zůstanou zachovány. Akci nelze vrátit zpět." } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Tato akce odstraní všechny akce, globální zkratku, nastavení poskytovatelů a ostatní volby. API klíče v Keychainu zůstanou zachovány. Akci nelze vrátit zpět." } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "This action will remove all actions, the global shortcut, provider settings, and other options. API keys in the Keychain will remain. This cannot be undone." } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Esta acción eliminará todas las acciones, el atajo global, la configuración de proveedores y otras opciones. Las claves API en el Llavero se conservarán. Esta acción no se puede deshacer." } }
       }
@@ -663,48 +663,84 @@
       }
     },
     "settings.providers.azure.deployment_url" : {
-      "comment" : "TextField placeholder",
+      "comment" : "Row label",
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Deployment URL (např. https://hub.openai.azure.com/openai/deployments/muj-model)" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Deployment URL (e.g. https://hub.openai.azure.com/openai/deployments/my-model)" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "URL del deployment (ej. https://hub.openai.azure.com/openai/deployments/mi-modelo)" } }
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Deployment URL" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Deployment URL" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "URL del deployment" } }
+      }
+    },
+    "settings.providers.azure.deployment_url_placeholder" : {
+      "comment" : "TextField placeholder: example deployment URL",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "https://hub.openai.azure.com/openai/deployments/muj-model" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "https://hub.openai.azure.com/openai/deployments/my-model" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "https://hub.openai.azure.com/openai/deployments/mi-modelo" } }
       }
     },
     "settings.providers.azure.deployment_name" : {
-      "comment" : "TextField placeholder",
+      "comment" : "Row label",
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Deployment name (jen pokud výše zadáváš pouze resource URL)" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Deployment name (only if entering resource URL above)" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Nombre del deployment (solo si introduces la URL del recurso arriba)" } }
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Deployment name" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Deployment name" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Nombre del deployment" } }
+      }
+    },
+    "settings.providers.azure.deployment_name_hint" : {
+      "comment" : "TextField placeholder + tooltip for the deployment name field",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "jen pokud výše zadáváš pouze resource URL" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "only if entering just the resource URL above" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "solo si introduces solo la URL del recurso arriba" } }
       }
     },
     "settings.providers.azure.api_version" : {
+      "comment" : "Row label",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "API verze" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "API version" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Versión de API" } }
+      }
+    },
+    "settings.providers.azure.api_version_placeholder" : {
       "comment" : "TextField placeholder. %@ = default version string",
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "API verze (výchozí: %@)" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "API version (default: %@)" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Versión de API (predeterminada: %@)" } }
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "výchozí: %@" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "default: %@" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "predeterminada: %@" } }
       }
     },
     "settings.providers.custom.base_url" : {
-      "comment" : "TextField placeholder",
+      "comment" : "Row label",
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Base URL (např. http://localhost:11434/v1)" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Base URL (e.g. http://localhost:11434/v1)" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "URL base (ej. http://localhost:11434/v1)" } }
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Base URL" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Base URL" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "URL base" } }
       }
     },
     "settings.providers.custom.api_version" : {
-      "comment" : "TextField placeholder",
+      "comment" : "Row label",
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "API verze (volitelné, přidá ?api-version=…)" } },
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "API version (optional, adds ?api-version=…)" } },
-        "es" : { "stringUnit" : { "state" : "translated", "value" : "Versión de API (opcional, añade ?api-version=…)" } }
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "API verze" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "API version" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Versión de API" } }
+      }
+    },
+    "settings.providers.custom.api_version_hint" : {
+      "comment" : "TextField placeholder + tooltip for the custom provider API version field",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "volitelné, přidá ?api-version=…" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "optional, adds ?api-version=…" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "opcional, añade ?api-version=…" } }
       }
     },
     "settings.providers.custom.effective_url" : {
@@ -737,6 +773,24 @@
         "cs" : { "stringUnit" : { "state" : "translated", "value" : "Aktualizovat modely" } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Update Models" } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Actualizar modelos" } }
+      }
+    },
+    "settings.providers.key_missing" : {
+      "comment" : "Tooltip on the key icon in a collapsed provider header",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "API klíč není uložen" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No API key saved" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Sin clave API guardada" } }
+      }
+    },
+    "settings.providers.key_saved" : {
+      "comment" : "Tooltip on the key icon in a collapsed provider header",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "API klíč uložen" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "API key saved" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Clave API guardada" } }
       }
     },
     "settings.providers.models_saved" : {
@@ -1063,7 +1117,7 @@
     "action.detail.label.provider" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Provider" } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Poskytovatel" } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Provider" } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Proveedor" } }
       }
@@ -1162,7 +1216,7 @@
       "comment" : "Markdown bold used for provider names",
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Pro cloudové providery (**OpenAI**, **Anthropic**) si vytvoř účet a vygeneruj API klíč. Vlastní nebo lokální modely (**Ollama**, **LM Studio**) žádný klíč nevyžadují." } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Pro cloudové poskytovatele (**OpenAI**, **Anthropic**) si vytvoř účet a vygeneruj API klíč. Vlastní nebo lokální modely (**Ollama**, **LM Studio**) žádný klíč nevyžadují." } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "For cloud providers (**OpenAI**, **Anthropic**), create an account and generate an API key. Custom or local models (**Ollama**, **LM Studio**) don't require a key." } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Para proveedores en la nube (**OpenAI**, **Anthropic**), crea una cuenta y genera una clave API. Los modelos locales o personalizados (**Ollama**, **LM Studio**) no requieren clave." } }
       }
@@ -1170,7 +1224,7 @@
     "about.setup.step2.title" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nakonfiguruj provider" } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nakonfiguruj poskytovatele" } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Configure a provider" } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Configura un proveedor" } }
       }
@@ -1179,7 +1233,7 @@
       "comment" : "Markdown bold used for UI element names",
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nastavení → záložka **Providery** → zadej adresu endpointu (pokud je potřeba) a API klíč → klikni **Uložit**." } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nastavení → záložka **Poskytovatelé** → zadej adresu endpointu (pokud je potřeba) a API klíč → klikni **Uložit**." } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Settings → **Providers** tab → enter endpoint URL (if needed) and API key → click **Save**." } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Preferencias → pestaña **Proveedores** → introduce la URL del endpoint (si es necesario) y la clave API → haz clic en **Guardar**." } }
       }
@@ -1414,7 +1468,7 @@
     "settings.providers.custom.new_name" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nový provider" } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nový poskytovatel" } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "New Provider" } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Nuevo proveedor" } }
       }
@@ -1422,7 +1476,7 @@
     "settings.providers.custom.unnamed" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nepojmenovaný provider" } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Nepojmenovaný poskytovatel" } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Unnamed Provider" } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Proveedor sin nombre" } }
       }
@@ -1462,7 +1516,7 @@
     "settings.providers.custom.delete" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Odebrat provider" } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Odebrat poskytovatele" } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove provider" } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Eliminar proveedor" } }
       }
@@ -1470,7 +1524,7 @@
     "settings.providers.custom.delete_confirm_title" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Odebrat provider?" } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Odebrat poskytovatele?" } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Remove provider?" } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "¿Eliminar proveedor?" } }
       }
@@ -1478,7 +1532,7 @@
     "settings.providers.custom.delete_confirm_message" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Odebere provider „%@\" včetně API klíče. Akce používající tento provider budou přepnuty na OpenAI." } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Odebere poskytovatele „%@\" včetně API klíče. Akce používající tohoto poskytovatele budou přepnuty na OpenAI." } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "This will remove provider \"%@\" and its API key. Actions using this provider will be reset to OpenAI." } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Se eliminará el proveedor \"%@\" y su clave API. Las acciones que usen este proveedor se restablecerán a OpenAI." } }
       }
@@ -1486,7 +1540,7 @@
     "settings.providers.add_custom" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Přidat vlastní provider" } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Přidat vlastního poskytovatele" } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Add custom provider" } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Añadir proveedor personalizado" } }
       }
@@ -1494,9 +1548,27 @@
     "settings.providers.model_filters" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Filtr modelů" } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Filtry modelů" } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Model filters" } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Filtros de modelos" } }
+      }
+    },
+    "settings.providers.model_filters.scope" : {
+      "comment" : "Footer under the model filters section explaining global scope",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Filtry platí pro nabídku modelů u všech poskytovatelů — v nastavení akcí i při aktualizaci modelů." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Filters apply to the model lists of all providers — in action settings and when updating models." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Los filtros se aplican a las listas de modelos de todos los proveedores — en la configuración de acciones y al actualizar modelos." } }
+      }
+    },
+    "settings.providers.section.providers" : {
+      "comment" : "Group header above the provider sections",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Poskytovatelé" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Providers" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Proveedores" } }
       }
     },
     "settings.providers.model_exclude_filter" : {
@@ -1526,7 +1598,7 @@
     "settings.providers.model_filter.hint_exclude" : {
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Skryje modely jejichž ID obsahuje daný řetězec (u všech providerů)." } },
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Skryje modely jejichž ID obsahuje daný řetězec (u všech poskytovatelů)." } },
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Hides models whose ID contains the given string (across all providers)." } },
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Oculta modelos cuyo ID contiene la cadena dada (en todos los proveedores)." } }
       }

--- a/Sources/JZLLMContext/Resources/Localizable.xcstrings
+++ b/Sources/JZLLMContext/Resources/Localizable.xcstrings
@@ -446,6 +446,51 @@
         "es" : { "stringUnit" : { "state" : "translated", "value" : "Añadir acción" } }
       }
     },
+    "settings.actions.enabled" : {
+      "comment" : "Toggle in the action detail editor",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Povolená" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Enabled" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Activada" } }
+      }
+    },
+    "settings.actions.default_toggle" : {
+      "comment" : "Toggle in the action detail editor; Enter runs the default action",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Výchozí akce (spustí Enter)" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Default action (runs on Enter)" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Acción predeterminada (se ejecuta con Enter)" } }
+      }
+    },
+    "settings.actions.empty_selection" : {
+      "comment" : "Detail pane placeholder when no action is selected",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Vyberte akci ze seznamu" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Select an action from the list" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Selecciona una acción de la lista" } }
+      }
+    },
+    "settings.actions.empty_list" : {
+      "comment" : "Detail pane placeholder when there are no actions at all",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Zatím žádné akce — přidejte první tlačítkem „Přidat akci\"." } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No actions yet — add one with \"Add Action\"." } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Aún no hay acciones — añade una con «Añadir acción»." } }
+      }
+    },
+    "settings.actions.section.parameters" : {
+      "comment" : "Section header in the action detail editor",
+      "extractionState" : "manual",
+      "localizations" : {
+        "cs" : { "stringUnit" : { "state" : "translated", "value" : "Parametry" } },
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Parameters" } },
+        "es" : { "stringUnit" : { "state" : "translated", "value" : "Parámetros" } }
+      }
+    },
     "settings.actions.new_name" : {
       "comment" : "Default name for a newly created action",
       "extractionState" : "manual",

--- a/Sources/JZLLMContext/UI/OverlayView.swift
+++ b/Sources/JZLLMContext/UI/OverlayView.swift
@@ -6,6 +6,7 @@ struct OverlayView: View {
     @ObservedObject var state: OverlayState
     let onClose: () -> Void
     let onOpenSettings: () -> Void
+    let onResultAppeared: () -> Void
 
     @StateObject private var engine = ActionEngine()
     @ObservedObject private var history = HistoryStore.shared
@@ -117,6 +118,9 @@ struct OverlayView: View {
             if current != knownClipboardChangeCount {
                 clipboardChanged = true
             }
+        }
+        .onChange(of: displayedResult != nil) { _, hasDisplayedResult in
+            if hasDisplayedResult { onResultAppeared() }
         }
         .onChange(of: engine.completedRunID) { _, completedID in
             guard completedID != nil, !engine.result.isEmpty else { return }

--- a/Sources/JZLLMContext/UI/OverlayWindowController.swift
+++ b/Sources/JZLLMContext/UI/OverlayWindowController.swift
@@ -15,6 +15,9 @@ final class OverlayWindowController: NSObject {
     private var panel: NSPanel?
     private let state = OverlayState()
     var onOpenSettings: (() -> Void)?
+    /// Set once the user resizes the panel by hand; from then on the
+    /// automatic height management backs off and their size wins.
+    private var userResizedPanel = false
 
     func showOverlay() {
         if panel == nil {
@@ -22,13 +25,31 @@ final class OverlayWindowController: NSObject {
             panel?.center()
         }
         state.triggerRefresh()
-        adjustPanelHeight()
+        if !userResizedPanel {
+            adjustPanelHeight()
+        }
         panel?.makeKeyAndOrderFront(nil)
     }
 
     private func adjustPanelHeight() {
         let actionCount = ConfigStore.shared.actions.filter(\.enabled).count
         let targetHeight = CGFloat(min(max(160 + actionCount * 44, 280), 620))
+        setPanelHeight(targetHeight, animate: false)
+    }
+
+    /// Grows the panel when a result arrives so the result area gets
+    /// usable space instead of squeezing under the action list.
+    private func expandForResult() {
+        guard !userResizedPanel, let panel else { return }
+        let maxHeight = ((panel.screen ?? NSScreen.main)?.visibleFrame.height ?? 800) - 40
+        let target = min(max(panel.frame.height, 560), maxHeight)
+        if target > panel.frame.height {
+            setPanelHeight(target, animate: true)
+        }
+    }
+
+    /// Resizes the panel keeping its top edge in place, clamped to the screen.
+    private func setPanelHeight(_ targetHeight: CGFloat, animate: Bool) {
         guard let panel = panel, panel.frame.height != targetHeight else { return }
         let currentFrame = panel.frame
         let newY = currentFrame.maxY - targetHeight
@@ -38,7 +59,8 @@ final class OverlayWindowController: NSObject {
         } else {
             clampedY = newY
         }
-        panel.setFrame(NSRect(x: currentFrame.minX, y: clampedY, width: currentFrame.width, height: targetHeight), display: true)
+        panel.setFrame(NSRect(x: currentFrame.minX, y: clampedY, width: currentFrame.width, height: targetHeight),
+                       display: true, animate: animate)
     }
 
     func hideOverlay() {
@@ -70,8 +92,19 @@ final class OverlayWindowController: NSObject {
         }, onOpenSettings: { [weak self] in
             self?.hideOverlay()
             self?.onOpenSettings?()
+        }, onResultAppeared: { [weak self] in
+            self?.expandForResult()
         })
         panel.contentView = NSHostingView(rootView: overlayView)
+        panel.delegate = self
         return panel
+    }
+}
+
+extension OverlayWindowController: NSWindowDelegate {
+    // Fires only for user-driven drag resizing, not for programmatic
+    // setFrame calls — exactly the signal that the user picked a size.
+    func windowDidEndLiveResize(_ notification: Notification) {
+        userResizedPanel = true
     }
 }

--- a/Sources/JZLLMContext/UI/SettingsView.swift
+++ b/Sources/JZLLMContext/UI/SettingsView.swift
@@ -878,7 +878,7 @@ struct SettingsView: View {
         if filters.wrappedValue.isEmpty {
             Text("—").foregroundStyle(.secondary).font(.caption)
         } else {
-            HStack(spacing: 4) {
+            FlowLayout(spacing: 4, lineSpacing: 4) {
                 ForEach(Array(filters.wrappedValue.enumerated()), id: \.offset) { idx, filter in
                     HStack(spacing: 3) {
                         Text(filter).font(.caption)
@@ -892,6 +892,7 @@ struct SettingsView: View {
                     .cornerRadius(UICornerRadius.small)
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/Sources/JZLLMContext/UI/SettingsView.swift
+++ b/Sources/JZLLMContext/UI/SettingsView.swift
@@ -46,6 +46,7 @@ struct SettingsView: View {
     @State private var newHeaderValue: [UUID: String] = [:]
     @State private var showDeleteProviderAlert = false
     @State private var providerToDelete: CustomProvider? = nil
+    @State private var expandedProviders: Set<String> = []
 
     private enum PatternField: Hashable { case label, regex }
     @FocusState private var patternFocus: PatternField?
@@ -450,8 +451,13 @@ struct SettingsView: View {
 
     private var providersTab: some View {
         Form {
+            // Model filters first — they shape what every provider's
+            // "Update Models" fetch shows, so they read as global settings.
+            modelFiltersSection
+
             // Built-in providers
-            Section("OpenAI") {
+            providerSection("OpenAI", provider: .openai, hasKey: !openaiKey.isEmpty,
+                            groupTitle: L("settings.providers.section.providers")) {
                 LabeledContent(L("settings.providers.api_key")) {
                     SecureField("", text: $openaiKey)
                         .onSubmit { saveKey(openaiKey, for: .openai) }
@@ -460,7 +466,7 @@ struct SettingsView: View {
                 fetchModelsRow(for: .openai)
                 testConnectionRow(for: .openai, key: openaiKey)
             }
-            Section("Anthropic") {
+            providerSection("Anthropic", provider: .anthropic, hasKey: !anthropicKey.isEmpty) {
                 LabeledContent(L("settings.providers.api_key")) {
                     SecureField("", text: $anthropicKey)
                         .onSubmit { saveKey(anthropicKey, for: .anthropic) }
@@ -469,7 +475,7 @@ struct SettingsView: View {
                 fetchModelsRow(for: .anthropic)
                 testConnectionRow(for: .anthropic, key: anthropicKey)
             }
-            Section("Google Gemini") {
+            providerSection("Google Gemini", provider: .gemini, hasKey: !geminiKey.isEmpty) {
                 LabeledContent(L("settings.providers.api_key")) {
                     SecureField("", text: $geminiKey)
                         .onSubmit { saveKey(geminiKey, for: .gemini) }
@@ -478,7 +484,7 @@ struct SettingsView: View {
                 fetchModelsRow(for: .gemini)
                 testConnectionRow(for: .gemini, key: geminiKey)
             }
-            Section("xAI Grok") {
+            providerSection("xAI Grok", provider: .grok, hasKey: !grokKey.isEmpty) {
                 LabeledContent(L("settings.providers.api_key")) {
                     SecureField("", text: $grokKey)
                         .onSubmit { saveKey(grokKey, for: .grok) }
@@ -487,7 +493,7 @@ struct SettingsView: View {
                 fetchModelsRow(for: .grok)
                 testConnectionRow(for: .grok, key: grokKey)
             }
-            Section("Azure AI (slot 1)") {
+            providerSection("Azure AI (slot 1)", provider: .azureOpenai, hasKey: !azureKey.isEmpty) {
                 Text(L("settings.providers.azure.description"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -496,7 +502,7 @@ struct SettingsView: View {
                         .onSubmit { saveKey(azureKey, for: .azureOpenai) }
                 }
                 LabeledContent(L("settings.providers.azure.deployment_url")) {
-                    TextField("", text: Binding(
+                    TextField(L("settings.providers.azure.deployment_url_placeholder"), text: Binding(
                         get: { config.azureEndpoint ?? "" },
                         set: {
                             config.azureEndpoint = $0.isEmpty ? nil : $0
@@ -505,16 +511,17 @@ struct SettingsView: View {
                     ))
                 }
                 LabeledContent(L("settings.providers.azure.deployment_name")) {
-                    TextField("", text: Binding(
+                    TextField(L("settings.providers.azure.deployment_name_hint"), text: Binding(
                         get: { config.azureDeploymentName ?? "" },
                         set: {
                             config.azureDeploymentName = $0.isEmpty ? nil : $0
                             ConfigStore.shared.update { $0.azureDeploymentName = config.azureDeploymentName }
                         }
                     ))
+                    .help(L("settings.providers.azure.deployment_name_hint"))
                 }
-                LabeledContent(String(format: L("settings.providers.azure.api_version"), AppConfig.defaultAzureAPIVersion)) {
-                    TextField("", text: Binding(
+                LabeledContent(L("settings.providers.azure.api_version")) {
+                    TextField(String(format: L("settings.providers.azure.api_version_placeholder"), AppConfig.defaultAzureAPIVersion), text: Binding(
                         get: { config.azureAPIVersion ?? "" },
                         set: {
                             config.azureAPIVersion = $0.isEmpty ? nil : $0
@@ -525,13 +532,13 @@ struct SettingsView: View {
                 saveButton(for: .azureOpenai, key: azureKey)
                 testConnectionRow(for: .azureOpenai, key: azureKey)
             }
-            Section("Azure AI (slot 2)") {
+            providerSection("Azure AI (slot 2)", provider: .azureOpenai2, hasKey: !azureKey2.isEmpty) {
                 LabeledContent(L("settings.providers.api_key")) {
                     SecureField("", text: $azureKey2)
                         .onSubmit { saveKey(azureKey2, for: .azureOpenai2) }
                 }
                 LabeledContent(L("settings.providers.azure.deployment_url")) {
-                    TextField("", text: Binding(
+                    TextField(L("settings.providers.azure.deployment_url_placeholder"), text: Binding(
                         get: { config.azureEndpoint2 ?? "" },
                         set: {
                             config.azureEndpoint2 = $0.isEmpty ? nil : $0
@@ -540,16 +547,17 @@ struct SettingsView: View {
                     ))
                 }
                 LabeledContent(L("settings.providers.azure.deployment_name")) {
-                    TextField("", text: Binding(
+                    TextField(L("settings.providers.azure.deployment_name_hint"), text: Binding(
                         get: { config.azureDeploymentName2 ?? "" },
                         set: {
                             config.azureDeploymentName2 = $0.isEmpty ? nil : $0
                             ConfigStore.shared.update { $0.azureDeploymentName2 = config.azureDeploymentName2 }
                         }
                     ))
+                    .help(L("settings.providers.azure.deployment_name_hint"))
                 }
-                LabeledContent(String(format: L("settings.providers.azure.api_version"), AppConfig.defaultAzureAPIVersion)) {
-                    TextField("", text: Binding(
+                LabeledContent(L("settings.providers.azure.api_version")) {
+                    TextField(String(format: L("settings.providers.azure.api_version_placeholder"), AppConfig.defaultAzureAPIVersion), text: Binding(
                         get: { config.azureAPIVersion2 ?? "" },
                         set: {
                             config.azureAPIVersion2 = $0.isEmpty ? nil : $0
@@ -580,13 +588,11 @@ struct SettingsView: View {
                                                baseURL: "")
                     config.customProviders.append(newCP)
                     ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                    expandedProviders.insert(newCP.id.uuidString)
                 } label: {
                     Label(L("settings.providers.add_custom"), systemImage: "plus")
                 }
             }
-
-            // Model filters
-            modelFiltersSection
         }
         .formStyle(.grouped)
         .onAppear {
@@ -601,6 +607,64 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - Collapsible Provider Section
+
+    private func expansionBinding(_ id: String) -> Binding<Bool> {
+        Binding(
+            get: { expandedProviders.contains(id) },
+            set: { expanded in
+                if expanded {
+                    expandedProviders.insert(id)
+                } else {
+                    expandedProviders.remove(id)
+                }
+            }
+        )
+    }
+
+    private func providerSection<Content: View>(
+        _ name: String,
+        provider: ProviderType,
+        hasKey: Bool,
+        showsKeyStatus: Bool = true,
+        groupTitle: String? = nil,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        Section {
+            DisclosureGroup(isExpanded: expansionBinding(provider.rawValue)) {
+                content()
+            } label: {
+                providerHeader(name, provider: provider, hasKey: hasKey, showsKeyStatus: showsKeyStatus)
+            }
+        } header: {
+            if let groupTitle {
+                Text(groupTitle)
+            }
+        }
+    }
+
+    private func providerHeader(_ name: String, provider: ProviderType,
+                                hasKey: Bool, showsKeyStatus: Bool) -> some View {
+        HStack(spacing: 8) {
+            Text(name)
+                .fontWeight(.medium)
+            Spacer()
+            if let presets = config.modelPresets[provider.rawValue], !presets.isEmpty {
+                Text(String(format: L("settings.providers.models_saved"), presets.count))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if showsKeyStatus {
+                Image(systemName: hasKey ? "key.fill" : "key")
+                    .font(.caption)
+                    .foregroundStyle(hasKey ? Color.green : Color.secondary)
+                    .help(L(hasKey ? "settings.providers.key_saved" : "settings.providers.key_missing"))
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { expansionBinding(provider.rawValue).wrappedValue.toggle() }
+    }
+
     // MARK: - Custom Provider Section
 
     @ViewBuilder
@@ -613,69 +677,77 @@ struct SettingsView: View {
         )
 
         Section {
-            LabeledContent(L("settings.providers.custom.name")) {
-                TextField("", text: cp.name)
-                    .onChange(of: cp.wrappedValue.name) { _, _ in
+            DisclosureGroup(isExpanded: expansionBinding(cpID.uuidString)) {
+                LabeledContent(L("settings.providers.custom.name")) {
+                    TextField("", text: cp.name)
+                        .onChange(of: cp.wrappedValue.name) { _, _ in
+                            ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                        }
+                }
+                LabeledContent(L("settings.providers.custom.base_url")) {
+                    TextField("http://localhost:11434/v1", text: cp.baseURL)
+                        .onChange(of: cp.wrappedValue.baseURL) { _, _ in
+                            ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                        }
+                }
+                LabeledContent(L("settings.providers.custom.api_version")) {
+                    TextField(L("settings.providers.custom.api_version_hint"), text: Binding(
+                        get: { cp.wrappedValue.apiVersion ?? "" },
+                        set: { cp.apiVersion.wrappedValue = $0.isEmpty ? nil : $0 }
+                    ))
+                    .help(L("settings.providers.custom.api_version_hint"))
+                    .onChange(of: cp.wrappedValue.apiVersion) { _, _ in
                         ConfigStore.shared.update { $0.customProviders = config.customProviders }
                     }
-            }
-            LabeledContent(L("settings.providers.custom.base_url")) {
-                TextField("https://…", text: cp.baseURL)
-                    .onChange(of: cp.wrappedValue.baseURL) { _, _ in
+                }
+                LabeledContent(L("settings.providers.custom.effective_url")) {
+                    Text(effectiveChatURL(baseURL: cp.wrappedValue.baseURL, apiVersion: cp.wrappedValue.apiVersion))
+                        .monospaced()
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Picker(L("settings.providers.token_param"), selection: cp.tokenParamStyle) {
+                    ForEach(TokenParamStyle.allCases, id: \.self) { style in
+                        Text(style.displayName).tag(style)
+                    }
+                }
+                .onChange(of: cp.wrappedValue.tokenParamStyle) { _, _ in
+                    ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                }
+                Toggle(L("settings.providers.custom.requires_key"), isOn: cp.requiresAPIKey)
+                    .onChange(of: cp.wrappedValue.requiresAPIKey) { _, _ in
                         ConfigStore.shared.update { $0.customProviders = config.customProviders }
                     }
-            }
-            LabeledContent(L("settings.providers.custom.api_version")) {
-                TextField("", text: Binding(
-                    get: { cp.wrappedValue.apiVersion ?? "" },
-                    set: { cp.apiVersion.wrappedValue = $0.isEmpty ? nil : $0 }
-                ))
-                .onChange(of: cp.wrappedValue.apiVersion) { _, _ in
-                    ConfigStore.shared.update { $0.customProviders = config.customProviders }
+                LabeledContent(L("settings.providers.api_key_optional")) {
+                    SecureField("", text: keyBinding)
+                        .onSubmit { saveKey(keyBinding.wrappedValue, for: provider) }
                 }
-            }
-            LabeledContent(L("settings.providers.custom.effective_url")) {
-                Text(effectiveChatURL(baseURL: cp.wrappedValue.baseURL, apiVersion: cp.wrappedValue.apiVersion))
-                    .monospaced()
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .textSelection(.enabled)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-            }
-            Picker(L("settings.providers.token_param"), selection: cp.tokenParamStyle) {
-                ForEach(TokenParamStyle.allCases, id: \.self) { style in
-                    Text(style.displayName).tag(style)
+                saveButton(for: provider, key: keyBinding.wrappedValue)
+
+                // Custom headers
+                customHeadersRows(cp: cp, cpID: cpID)
+
+                testConnectionRow(for: provider, key: keyBinding.wrappedValue)
+                fetchModelsRow(for: provider)
+
+                Button(role: .destructive) {
+                    providerToDelete = cp.wrappedValue
+                    showDeleteProviderAlert = true
+                } label: {
+                    Label(L("settings.providers.custom.delete"), systemImage: "trash")
+                        .foregroundStyle(.red)
                 }
-            }
-            .onChange(of: cp.wrappedValue.tokenParamStyle) { _, _ in
-                ConfigStore.shared.update { $0.customProviders = config.customProviders }
-            }
-            Toggle(L("settings.providers.custom.requires_key"), isOn: cp.requiresAPIKey)
-                .onChange(of: cp.wrappedValue.requiresAPIKey) { _, _ in
-                    ConfigStore.shared.update { $0.customProviders = config.customProviders }
-                }
-            LabeledContent(L("settings.providers.api_key_optional")) {
-                SecureField("", text: keyBinding)
-                    .onSubmit { saveKey(keyBinding.wrappedValue, for: provider) }
-            }
-            saveButton(for: provider, key: keyBinding.wrappedValue)
-
-            // Custom headers
-            customHeadersRows(cp: cp, cpID: cpID)
-
-            testConnectionRow(for: provider, key: keyBinding.wrappedValue)
-            fetchModelsRow(for: provider)
-
-            Button(role: .destructive) {
-                providerToDelete = cp.wrappedValue
-                showDeleteProviderAlert = true
             } label: {
-                Label(L("settings.providers.custom.delete"), systemImage: "trash")
-                    .foregroundStyle(.red)
+                providerHeader(
+                    cp.wrappedValue.name.isEmpty ? L("settings.providers.custom.unnamed") : cp.wrappedValue.name,
+                    provider: provider,
+                    hasKey: !(customProviderKeys[cpID.uuidString] ?? "").isEmpty,
+                    showsKeyStatus: cp.wrappedValue.requiresAPIKey
+                )
             }
-        } header: {
-            Text(cp.wrappedValue.name.isEmpty ? L("settings.providers.custom.unnamed") : cp.wrappedValue.name)
         }
     }
 
@@ -749,47 +821,56 @@ struct SettingsView: View {
     // MARK: - Model Filters Section
 
     private var modelFiltersSection: some View {
-        Group {
-            Section {
-                filterTagsRow(
-                    filters: $config.modelExcludeFilters,
-                    onRemove: { idx in
-                        config.modelExcludeFilters.remove(at: idx)
-                        ConfigStore.shared.update { $0.modelExcludeFilters = config.modelExcludeFilters }
-                    }
-                )
-                HStack(spacing: 6) {
-                    TextField(L("settings.providers.model_filter.placeholder"), text: $newExcludeFilter)
-                        .onSubmit { addExcludeFilter() }
-                    Button(L("common.add")) { addExcludeFilter() }
-                        .disabled(newExcludeFilter.isEmpty)
+        Section {
+            modelFilterRow(
+                title: L("settings.providers.model_exclude_filter"),
+                hint: L("settings.providers.model_filter.hint_exclude"),
+                filters: $config.modelExcludeFilters,
+                newFilter: $newExcludeFilter,
+                onAdd: addExcludeFilter,
+                onRemove: { idx in
+                    config.modelExcludeFilters.remove(at: idx)
+                    ConfigStore.shared.update { $0.modelExcludeFilters = config.modelExcludeFilters }
                 }
-            } header: {
-                Text(L("settings.providers.model_exclude_filter"))
-            } footer: {
-                Text(L("settings.providers.model_filter.hint_exclude"))
-            }
-
-            Section {
-                filterTagsRow(
-                    filters: $config.modelIncludeFilters,
-                    onRemove: { idx in
-                        config.modelIncludeFilters.remove(at: idx)
-                        ConfigStore.shared.update { $0.modelIncludeFilters = config.modelIncludeFilters }
-                    }
-                )
-                HStack(spacing: 6) {
-                    TextField(L("settings.providers.model_filter.placeholder"), text: $newIncludeFilter)
-                        .onSubmit { addIncludeFilter() }
-                    Button(L("common.add")) { addIncludeFilter() }
-                        .disabled(newIncludeFilter.isEmpty)
+            )
+            modelFilterRow(
+                title: L("settings.providers.model_include_filter"),
+                hint: L("settings.providers.model_filter.hint_include"),
+                filters: $config.modelIncludeFilters,
+                newFilter: $newIncludeFilter,
+                onAdd: addIncludeFilter,
+                onRemove: { idx in
+                    config.modelIncludeFilters.remove(at: idx)
+                    ConfigStore.shared.update { $0.modelIncludeFilters = config.modelIncludeFilters }
                 }
-            } header: {
-                Text(L("settings.providers.model_include_filter"))
-            } footer: {
-                Text(L("settings.providers.model_filter.hint_include"))
-            }
+            )
+        } header: {
+            Text(L("settings.providers.model_filters"))
+        } footer: {
+            Text(L("settings.providers.model_filters.scope"))
         }
+    }
+
+    @ViewBuilder
+    private func modelFilterRow(title: String, hint: String,
+                                filters: Binding<[String]>, newFilter: Binding<String>,
+                                onAdd: @escaping () -> Void,
+                                onRemove: @escaping (Int) -> Void) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .fontWeight(.medium)
+            filterTagsRow(filters: filters, onRemove: onRemove)
+            HStack(spacing: 6) {
+                TextField(L("settings.providers.model_filter.placeholder"), text: newFilter)
+                    .onSubmit { onAdd() }
+                Button(L("common.add")) { onAdd() }
+                    .disabled(newFilter.wrappedValue.isEmpty)
+            }
+            Text(hint)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
     }
 
     @ViewBuilder

--- a/Sources/JZLLMContext/UI/SettingsView.swift
+++ b/Sources/JZLLMContext/UI/SettingsView.swift
@@ -47,6 +47,7 @@ struct SettingsView: View {
     @State private var showDeleteProviderAlert = false
     @State private var providerToDelete: CustomProvider? = nil
     @State private var expandedProviders: Set<String> = []
+    @State private var selectedActionID: UUID?
 
     private enum PatternField: Hashable { case label, regex }
     @FocusState private var patternFocus: PatternField?
@@ -390,43 +391,25 @@ struct SettingsView: View {
     // MARK: - Actions Tab
 
     private var actionsTab: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            List {
-                ForEach($config.actions) { $action in
-                    ActionRow(action: $action, onSetDefault: {
-                        let targetID = action.id
-                        for i in config.actions.indices {
-                            config.actions[i].isDefault = config.actions[i].id == targetID
-                        }
-                        ConfigStore.shared.update { $0.actions = config.actions }
-                    }, onDelete: {
-                        config.actions.removeAll { $0.id == action.id }
-                        ConfigStore.shared.update { $0.actions = config.actions }
-                    })
-                }
-                .onMove { from, to in
-                    config.actions.move(fromOffsets: from, toOffset: to)
-                    ConfigStore.shared.update { $0.actions = config.actions }
-                }
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                actionList
+                    .frame(width: 230)
+                Divider()
+                actionDetail
             }
             Divider()
             HStack {
-                Button(L("settings.actions.add")) {
-                    config.actions.append(Action(
-                        name: L("settings.actions.new_name"),
-                        systemPrompt: "",
-                        provider: .openai,
-                        model: "gpt-5.5",
-                        enabled: true
-                    ))
-                    ConfigStore.shared.update { $0.actions = config.actions }
-                }
+                Button(L("settings.actions.add")) { addAction() }
                 Spacer()
                 Button(L("settings.actions.import")) { importActions() }
                 Button(L("settings.actions.export")) { exportActions() }
                     .disabled(config.actions.isEmpty)
             }
             .padding(12)
+        }
+        .onAppear {
+            if selectedActionID == nil { selectedActionID = config.actions.first?.id }
         }
         .alert(L("settings.alert.import_actions.title"), isPresented: $showImportAlert) {
             Button(L("settings.alert.import_actions.add")) {
@@ -438,6 +421,7 @@ struct SettingsView: View {
                 let fresh = importedActions.map { var a = $0; a.id = UUID(); return a }
                 config.actions = fresh
                 ConfigStore.shared.update { $0.actions = config.actions }
+                selectedActionID = config.actions.first?.id
             }
             Button(L("common.cancel"), role: .cancel) {}
         } message: {
@@ -445,6 +429,113 @@ struct SettingsView: View {
                         importedActions.count,
                         importedActions.count == 1 ? L("settings.alert.import_actions.singular") : L("settings.alert.import_actions.plural")))
         }
+    }
+
+    private var actionList: some View {
+        List(selection: $selectedActionID) {
+            ForEach(config.actions) { action in
+                HStack(spacing: 8) {
+                    Toggle("", isOn: Binding(
+                        get: { action.enabled },
+                        set: { val in updateAction(action.id) { $0.enabled = val } }
+                    ))
+                    .labelsHidden()
+                    .controlSize(.small)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(action.name.isEmpty ? L("settings.actions.new_name") : action.name)
+                            .lineLimit(1)
+                        Text("\(action.provider.displayName) · \(action.model)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                    Spacer()
+                    if action.isDefault {
+                        Image(systemName: "return")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .help(L("action.row.help.is_default"))
+                    }
+                }
+                .padding(.vertical, 2)
+                .tag(action.id)
+            }
+            .onMove { from, to in
+                config.actions.move(fromOffsets: from, toOffset: to)
+                ConfigStore.shared.update { $0.actions = config.actions }
+            }
+        }
+        .listStyle(.inset)
+    }
+
+    @ViewBuilder
+    private var actionDetail: some View {
+        if let id = selectedActionID, let binding = actionBinding(for: id) {
+            ActionDetailEditor(
+                action: binding,
+                onSetDefault: {
+                    for i in config.actions.indices {
+                        config.actions[i].isDefault = config.actions[i].id == id
+                    }
+                    ConfigStore.shared.update { $0.actions = config.actions }
+                },
+                onDelete: { deleteAction(id) }
+            )
+            // Recreate the editor per selection so its @State model-picker
+            // fields re-sync via onAppear for the newly selected action.
+            .id(id)
+        } else {
+            VStack {
+                Spacer()
+                Text(config.actions.isEmpty ? L("settings.actions.empty_list") : L("settings.actions.empty_selection"))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding()
+                Spacer()
+            }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    private func actionBinding(for id: UUID) -> Binding<Action>? {
+        guard let current = config.actions.first(where: { $0.id == id }) else { return nil }
+        return Binding(
+            get: { config.actions.first(where: { $0.id == id }) ?? current },
+            set: { newVal in
+                guard let i = config.actions.firstIndex(where: { $0.id == id }) else { return }
+                config.actions[i] = newVal
+                ConfigStore.shared.update { $0.actions = config.actions }
+            }
+        )
+    }
+
+    private func updateAction(_ id: UUID, _ mutate: (inout Action) -> Void) {
+        guard let i = config.actions.firstIndex(where: { $0.id == id }) else { return }
+        mutate(&config.actions[i])
+        ConfigStore.shared.update { $0.actions = config.actions }
+    }
+
+    private func addAction() {
+        let action = Action(
+            name: L("settings.actions.new_name"),
+            systemPrompt: "",
+            provider: .openai,
+            model: "gpt-5.5",
+            enabled: true
+        )
+        config.actions.append(action)
+        ConfigStore.shared.update { $0.actions = config.actions }
+        selectedActionID = action.id
+    }
+
+    private func deleteAction(_ id: UUID) {
+        guard let idx = config.actions.firstIndex(where: { $0.id == id }) else { return }
+        config.actions.remove(at: idx)
+        ConfigStore.shared.update { $0.actions = config.actions }
+        selectedActionID = config.actions.indices.contains(idx)
+            ? config.actions[idx].id
+            : config.actions.last?.id
     }
 
     // MARK: - Providers Tab
@@ -497,6 +588,7 @@ struct SettingsView: View {
                 Text(L("settings.providers.azure.description"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 LabeledContent(L("settings.providers.api_key")) {
                     SecureField("", text: $azureKey)
                         .onSubmit { saveKey(azureKey, for: .azureOpenai) }
@@ -740,6 +832,7 @@ struct SettingsView: View {
                     Label(L("settings.providers.custom.delete"), systemImage: "trash")
                         .foregroundStyle(.red)
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
             } label: {
                 providerHeader(
                     cp.wrappedValue.name.isEmpty ? L("settings.providers.custom.unnamed") : cp.wrappedValue.name,
@@ -937,10 +1030,12 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         if let error = fetchError[provider] {
             Text(error)
                 .font(.caption)
                 .foregroundStyle(.red)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -984,10 +1079,12 @@ struct SettingsView: View {
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         if let error = testError[provider] {
             Text(error)
                 .font(.caption)
                 .foregroundStyle(.red)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
@@ -1019,6 +1116,7 @@ struct SettingsView: View {
                     .foregroundStyle(saved ? .green : .red)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private func saveKey(_ key: String, for provider: ProviderType) {
@@ -1272,44 +1370,113 @@ private struct ModelReviewSheet: View {
     }
 }
 
-// MARK: - Action Row
+// MARK: - Action Detail Editor
 
-private struct ActionRow: View {
+private struct ActionDetailEditor: View {
     @Binding var action: Action
     var onSetDefault: () -> Void
     var onDelete: () -> Void
-    @State private var pickerModel: String = ""
-    @State private var customModelText: String = ""
+    @State private var pickerModel: String
+    @State private var customModelText: String
     @State private var confirmDelete = false
 
-    private let customSentinel = "__custom__"
+    private static let customSentinel = "__custom__"
+    private var customSentinel: String { Self.customSentinel }
 
     private var isCustomModel: Bool { pickerModel == customSentinel }
 
+    // The picker state must be seeded in init: the editor is recreated per
+    // selected action via .id(_:), and onAppear does not fire reliably on
+    // those identity swaps, which left the model picker blank.
+    init(action: Binding<Action>, onSetDefault: @escaping () -> Void, onDelete: @escaping () -> Void) {
+        self._action = action
+        self.onSetDefault = onSetDefault
+        self.onDelete = onDelete
+        let current = action.wrappedValue
+        let presetIDs = current.provider.effectiveModels().map(\.id)
+        if !presetIDs.isEmpty && presetIDs.contains(current.model) {
+            self._pickerModel = State(initialValue: current.model)
+            self._customModelText = State(initialValue: "")
+        } else {
+            self._pickerModel = State(initialValue: Self.customSentinel)
+            self._customModelText = State(initialValue: current.model)
+        }
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Toggle("", isOn: $action.enabled)
-                    .labelsHidden()
-                TextField(L("action.row.name_placeholder"), text: $action.name)
-                    .font(.headline)
-                Spacer()
-                Button {
-                    onSetDefault()
-                } label: {
-                    Image(systemName: action.isDefault ? "return.left" : "return")
-                        .foregroundStyle(action.isDefault ? Color.accentColor : Color.secondary.opacity(0.5))
-                        .fontWeight(action.isDefault ? .semibold : .regular)
+        Form {
+            Section {
+                LabeledContent(L("action.detail.label.name")) {
+                    TextField(L("action.row.name_placeholder"), text: $action.name)
                 }
-                .buttonStyle(.plain)
+                Toggle(L("settings.actions.enabled"), isOn: $action.enabled)
+                Toggle(L("settings.actions.default_toggle"), isOn: Binding(
+                    get: { action.isDefault },
+                    set: { isOn in
+                        if isOn {
+                            onSetDefault()
+                        } else {
+                            action.isDefault = false
+                        }
+                    }
+                ))
                 .help(action.isDefault ? L("action.row.help.is_default") : L("action.row.help.set_default"))
-                Button {
+            }
+            Section {
+                Picker(L("action.detail.label.provider"), selection: $action.provider) {
+                    ForEach(ProviderType.allCases, id: \.self) { provider in
+                        Text(provider.displayName).tag(provider)
+                    }
+                }
+                .onChange(of: action.provider) {
+                    let presets = action.provider.effectiveModels()
+                    if presets.isEmpty {
+                        action.model = ""
+                        pickerModel = customSentinel
+                        customModelText = ""
+                    } else {
+                        let first = presets.first!.id
+                        action.model = first
+                        pickerModel = first
+                        customModelText = ""
+                    }
+                }
+                modelRow
+            }
+            Section(L("action.detail.label.system_prompt")) {
+                TextEditor(text: $action.systemPrompt)
+                    .font(.callout)
+                    .frame(minHeight: 200, maxHeight: 400)
+            }
+            Section(L("settings.actions.section.parameters")) {
+                LabeledContent(String(format: L("action.row.temperature"), action.temperature)) {
+                    Slider(value: $action.temperature, in: 0.0...2.0, step: 0.1)
+                        .frame(maxWidth: 220)
+                }
+                LabeledContent(L("action.row.max_tokens")) {
+                    HStack {
+                        TextField("", value: $action.maxTokens, format: .number)
+                            .frame(width: 80)
+                            .multilineTextAlignment(.trailing)
+                        Stepper("", value: $action.maxTokens, in: 256...32000, step: 256)
+                            .labelsHidden()
+                    }
+                }
+                Picker(L("action.row.copy_close"), selection: $action.autoCopyClose) {
+                    ForEach(AutoCopyClose.allCases, id: \.self) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                Toggle(L("action.row.ignore_clipboard"), isOn: $action.ignoreClipboard)
+                    .help(L("action.row.help.ignore_clipboard"))
+            }
+            Section {
+                Button(role: .destructive) {
                     confirmDelete = true
                 } label: {
-                    Image(systemName: "trash")
-                        .foregroundStyle(.red.opacity(0.8))
+                    Label(L("action.row.delete.button"), systemImage: "trash")
+                        .foregroundStyle(.red)
                 }
-                .buttonStyle(.plain)
                 .confirmationDialog(
                     String(format: L("action.row.delete.confirm"), action.name),
                     isPresented: $confirmDelete,
@@ -1318,25 +1485,9 @@ private struct ActionRow: View {
                     Button(L("action.row.delete.button"), role: .destructive) { onDelete() }
                 }
             }
-
-            providerModelRow
-
-            TextEditor(text: $action.systemPrompt)
-                .font(.callout)
-                .frame(minHeight: 60, maxHeight: 100)
-                .overlay(RoundedRectangle(cornerRadius: UICornerRadius.small).strokeBorder(Color(nsColor: .separatorColor), lineWidth: 0.5))
-
-            parametersRow
         }
-        .padding(.vertical, 6)
+        .formStyle(.grouped)
         .onAppear { syncPickerFromAction() }
-        .onChange(of: action) {
-            ConfigStore.shared.update { store in
-                if let idx = store.actions.firstIndex(where: { $0.id == action.id }) {
-                    store.actions[idx] = action
-                }
-            }
-        }
     }
 
     private func syncPickerFromAction() {
@@ -1350,105 +1501,37 @@ private struct ActionRow: View {
         }
     }
 
-    private var providerModelRow: some View {
-        HStack(spacing: 6) {
-            Picker("Provider", selection: $action.provider) {
-                ForEach(ProviderType.allCases, id: \.self) { provider in
-                    Text(provider.displayName).tag(provider)
-                }
-            }
-            .labelsHidden()
-            .frame(width: 120)
-            .onChange(of: action.provider) {
-                let presets = action.provider.effectiveModels()
-                if presets.isEmpty {
-                    action.model = ""
-                    pickerModel = customSentinel
-                    customModelText = ""
-                } else {
-                    let first = presets.first!.id
-                    action.model = first
-                    pickerModel = first
-                    customModelText = ""
-                }
-            }
-
-            if action.provider.effectiveModels().isEmpty {
+    @ViewBuilder
+    private var modelRow: some View {
+        if action.provider.effectiveModels().isEmpty {
+            LabeledContent(L("action.detail.label.model")) {
                 TextField(L("action.row.model_placeholder"), text: $customModelText)
-                    .frame(width: 260)
                     .onChange(of: customModelText) {
                         if !customModelText.isEmpty { action.model = customModelText }
                     }
-            } else {
-                Picker("Model", selection: $pickerModel) {
-                    ForEach(action.provider.effectiveModels()) { preset in
-                        Text(preset.isRecommended ? "\(preset.displayName) \(L("action.row.recommended"))" : preset.displayName)
-                            .tag(preset.id)
-                    }
-                    Divider()
-                    Text(L("action.row.custom_model")).tag(customSentinel)
+            }
+        } else {
+            Picker(L("action.detail.label.model"), selection: $pickerModel) {
+                ForEach(action.provider.effectiveModels()) { preset in
+                    Text(preset.isRecommended ? "\(preset.displayName) \(L("action.row.recommended"))" : preset.displayName)
+                        .tag(preset.id)
                 }
-                .labelsHidden()
-                .frame(width: 200)
-                .onChange(of: pickerModel) {
-                    if pickerModel != customSentinel {
-                        action.model = pickerModel
-                        customModelText = ""
-                    }
+                Divider()
+                Text(L("action.row.custom_model")).tag(customSentinel)
+            }
+            .onChange(of: pickerModel) {
+                if pickerModel != customSentinel {
+                    action.model = pickerModel
+                    customModelText = ""
                 }
+            }
 
-                if isCustomModel {
+            if isCustomModel {
+                LabeledContent("") {
                     TextField(L("action.row.model_placeholder"), text: $customModelText)
-                        .frame(width: 160)
                         .onChange(of: customModelText) {
                             if !customModelText.isEmpty { action.model = customModelText }
                         }
-                }
-            }
-        }
-    }
-
-    private var parametersRow: some View {
-        HStack(spacing: 16) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(String(format: L("action.row.temperature"), action.temperature))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Slider(value: $action.temperature, in: 0.0...2.0, step: 0.1)
-                    .frame(width: 160)
-            }
-
-            Spacer()
-
-            Toggle(L("action.row.ignore_clipboard"), isOn: $action.ignoreClipboard)
-                .toggleStyle(.checkbox)
-                .font(.caption)
-                .help(L("action.row.help.ignore_clipboard"))
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(L("action.row.copy_close"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                Picker("", selection: $action.autoCopyClose) {
-                    ForEach(AutoCopyClose.allCases, id: \.self) { mode in
-                        Text(mode.displayName).tag(mode)
-                    }
-                }
-                .labelsHidden()
-                .frame(width: 120)
-                .pickerStyle(.menu)
-            }
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(L("action.row.max_tokens"))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                HStack {
-                    TextField("", value: $action.maxTokens, format: .number)
-                        .frame(width: 80)
-                        .multilineTextAlignment(.trailing)
-                    Stepper("", value: $action.maxTokens, in: 256...32000, step: 256)
-                        .labelsHidden()
                 }
             }
         }

--- a/Sources/JZLLMContext/UI/UIConstants.swift
+++ b/Sources/JZLLMContext/UI/UIConstants.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import SwiftUI
 
 /// Shared corner-radius values for consistent rounding across the UI.
 enum UICornerRadius {
@@ -6,4 +7,61 @@ enum UICornerRadius {
     static let small: CGFloat = 4
     /// Cards, panels and content containers.
     static let large: CGFloat = 8
+}
+
+/// Leading-aligned flow layout: places subviews in rows and wraps to a new
+/// row when the next subview would exceed the proposed width. Used for tag
+/// chips (e.g. model filters) that would otherwise overflow a fixed HStack.
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 4
+    var lineSpacing: CGFloat = 4
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let rows = computeRows(maxWidth: proposal.width ?? .infinity, subviews: subviews)
+        let width = rows.map(\.width).max() ?? 0
+        let height = rows.reduce(0) { $0 + $1.height } + lineSpacing * CGFloat(max(rows.count - 1, 0))
+        return CGSize(width: proposal.width ?? width, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var y = bounds.minY
+        for row in computeRows(maxWidth: bounds.width, subviews: subviews) {
+            var x = bounds.minX
+            for index in row.indices {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(
+                    at: CGPoint(x: x, y: y + (row.height - size.height) / 2),
+                    proposal: ProposedViewSize(size)
+                )
+                x += size.width + spacing
+            }
+            y += row.height + lineSpacing
+        }
+    }
+
+    private struct Row {
+        var indices: [Int] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private func computeRows(maxWidth: CGFloat, subviews: Subviews) -> [Row] {
+        var rows: [Row] = []
+        var current = Row()
+        for (index, subview) in subviews.enumerated() {
+            let size = subview.sizeThatFits(.unspecified)
+            let needed = current.indices.isEmpty ? size.width : current.width + spacing + size.width
+            if !current.indices.isEmpty && needed > maxWidth {
+                rows.append(current)
+                current = Row()
+            }
+            current.width = current.indices.isEmpty ? size.width : current.width + spacing + size.width
+            current.indices.append(index)
+            current.height = max(current.height, size.height)
+        }
+        if !current.indices.isEmpty {
+            rows.append(current)
+        }
+        return rows
+    }
 }


### PR DESCRIPTION
Dokončuje zbývající body z #22 (4, 5, 6, 7, 11, 16) — tím je celá revize hotová.

## Providers tab (body 6, 7)
- Každý poskytovatel je sbalovací `DisclosureGroup` (výchozí stav sbaleno); hlavička ukazuje stav API klíče a počet uložených modelů, kliknout lze na celý řádek hlavičky
- Filtry modelů přesunuty na začátek tabu, sloučeny do jedné sekce s footerem vysvětlujícím globální platnost; nad poskytovateli skupinový nadpis
- Dlouhé labely Azure/custom polí zkráceny, příklady a vysvětlivky přesunuty do placeholderů a tooltipů
- Řádky uvnitř `DisclosureGroup` zarovnány doleva (jinak se centrují)

## Actions tab (bod 11)
- Master–detail layout: vlevo kompaktní seznam akcí (toggle, název, poskytovatel · model, ↩), vpravo plnohodnotný editor s velkým polem promptu (200–400 pt) a parametry po řádcích
- `ActionDetailEditor` se vytváří per výběr přes `.id(_:)`; stav model pickeru se seeduje v `init` — `onAppear` se při výměně identity spolehlivě nevolá a picker zůstával prázdný (ověřeno za běhu přes accessibility)

## Overlay (body 4, 5)
- Panel se při zobrazení výsledku animovaně zvětší (min. 560 pt)
- `windowDidEndLiveResize` označí ruční resize uživatele; od té chvíle se automatická správa výšky vypne

## Ostatní
- Bod 16: tagy filtrů modelů se zalamují přes nový sdílený `FlowLayout` (Layout protokol)
- České texty: anglicismus „provider" nahrazen „poskytovatel" v celém UI i české polovině README (kódové identifikátory beze změny)
- Nové lokalizační klíče cs/en/es; CLAUDE.md doplněn o nové konvence

## Známé navazující kroky (mimo PR)
- Screenshoty v `docs/` neodpovídají novému layoutu tabů Akce a Poskytovatelé
- Keychain prompty (ad-hoc podpis) — odloženo na příště

🤖 Generated with [Claude Code](https://claude.com/claude-code)